### PR TITLE
Add winter adventure log editor with photo library support

### DIFF
--- a/content/winter/books.json
+++ b/content/winter/books.json
@@ -1,0 +1,10 @@
+{
+  "books": [
+    {
+      "slug": "snows-of-summer",
+      "title": "Snows of Summer",
+      "description": "The first volume of the Reign of Winter adventure path, where Irrisen's eternal frost begins to creep across Golarion.",
+      "coverImage": "/images/winter/baba_yaga_hero.jpg"
+    }
+  ]
+}

--- a/content/winter/entries.json
+++ b/content/winter/entries.json
@@ -1,0 +1,52 @@
+{
+  "entries": [
+    {
+      "id": "entry-001",
+      "slug": "crossing-the-border",
+      "bookSlug": "snows-of-summer",
+      "title": "Crossing the Border",
+      "subtitle": "Unnatural winter grips Heldren",
+      "publishedAt": "2024-01-15T18:30:00.000Z",
+      "excerpt": "Our heroes answered Heldren's call for aid and stepped into the Border Wood, where the summer heat gave way to killing frost.",
+      "content": {
+        "type": "doc",
+        "content": [
+          {
+            "type": "heading",
+            "attrs": { "level": 2 },
+            "content": [
+              { "type": "text", "text": "Crossing the Border" }
+            ]
+          },
+          {
+            "type": "paragraph",
+            "content": [
+              {
+                "type": "text",
+                "text": "Heldren's council begged for help after patrols vanished near the Border Wood. Answering the call, our companions packed winter gear and blessings for the road."
+              }
+            ]
+          },
+          {
+            "type": "paragraph",
+            "content": [
+              {
+                "type": "text",
+                "text": "{{photo:winter-campfire}}"
+              }
+            ]
+          },
+          {
+            "type": "paragraph",
+            "content": [
+              {
+                "type": "text",
+                "text": "Within hours the summer heat died, replaced by a razor wind that carried flurries of strange blue snow. The trail of the missing caravan led deeper into the unnatural storm."
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/content/winter/photos.json
+++ b/content/winter/photos.json
@@ -1,0 +1,13 @@
+{
+  "photos": [
+    {
+      "id": "winter-campfire",
+      "relativePath": "/images/winter/shadowcat.jpg",
+      "alt": "A mysterious shadowcat perched against a snowy backdrop",
+      "caption": "A shadowcat familiar keeps watch as the heroes make camp on the Irriseni border.",
+      "credit": "Campaign photography",
+      "createdAt": "2024-01-10T12:00:00.000Z",
+      "updatedAt": "2024-01-10T12:00:00.000Z"
+    }
+  ]
+}

--- a/src/app/(winter)/adventure-log/page.tsx
+++ b/src/app/(winter)/adventure-log/page.tsx
@@ -1,0 +1,67 @@
+import Link from 'next/link'
+import { getWinterBooks, getWinterEntries } from '@/lib/winter/store'
+
+export const revalidate = 0
+
+export default async function WinterAdventureLogPage() {
+  const [books, entries] = await Promise.all([getWinterBooks(), getWinterEntries()])
+  const entriesByBook = books.map((book) => ({
+    book,
+    entries: entries.filter((entry) => entry.bookSlug === book.slug),
+  }))
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-12 px-4 py-16 text-slate-100">
+      <header className="space-y-4 text-center">
+        <h1 className="text-4xl font-bold">Reign of Winter Adventure Log</h1>
+        <p className="text-lg text-slate-300">
+          Track every step of our heroes as they carve a path through the endless snows.
+        </p>
+      </header>
+
+      {entriesByBook.map(({ book, entries }) => (
+        <section key={book.slug} className="space-y-6 rounded-2xl border border-slate-700/70 bg-slate-900/60 p-8">
+          <header className="space-y-2">
+            <h2 className="text-3xl font-semibold text-cyan-200">{book.title}</h2>
+            {book.description && <p className="text-slate-300">{book.description}</p>}
+          </header>
+
+          {entries.length === 0 ? (
+            <p className="text-slate-400">No entries yet. Check back soon!</p>
+          ) : (
+            <ul className="space-y-4">
+              {entries.map((entry) => (
+                <li key={entry.id} className="rounded-lg border border-slate-700/60 bg-slate-900/40 p-4">
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-baseline sm:justify-between">
+                    <div>
+                      <h3 className="text-2xl font-semibold text-slate-100">
+                        <Link href={`/book/${book.slug}/${entry.slug}`} className="hover:text-cyan-200">
+                          {entry.title}
+                        </Link>
+                      </h3>
+                      {entry.subtitle && (
+                        <p className="text-sm text-slate-400">{entry.subtitle}</p>
+                      )}
+                    </div>
+                    <time className="text-xs uppercase tracking-wide text-slate-500">
+                      {new Date(entry.publishedAt).toLocaleDateString()}
+                    </time>
+                  </div>
+                  <p className="mt-3 text-sm text-slate-300">{entry.excerpt}</p>
+                  <div className="mt-3 text-right">
+                    <Link
+                      href={`/book/${book.slug}/${entry.slug}`}
+                      className="text-sm font-semibold text-cyan-300 hover:text-cyan-200"
+                    >
+                      Read entry →
+                    </Link>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      ))}
+    </div>
+  )
+}

--- a/src/app/(winter)/book/[bookSlug]/[entrySlug]/page.tsx
+++ b/src/app/(winter)/book/[bookSlug]/[entrySlug]/page.tsx
@@ -1,0 +1,69 @@
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { WinterAdventureRenderer } from '@/components/winter/adventure/WinterAdventureRenderer'
+import { getWinterBook, getWinterEntriesForBook, listWinterPhotos } from '@/lib/winter/store'
+
+interface PageProps {
+  params: {
+    bookSlug: string
+    entrySlug: string
+  }
+}
+
+export const revalidate = 0
+
+export default async function WinterEntryPage({ params }: PageProps) {
+  const [book, entries, photos] = await Promise.all([
+    getWinterBook(params.bookSlug),
+    getWinterEntriesForBook(params.bookSlug),
+    listWinterPhotos(),
+  ])
+
+  if (!book) {
+    notFound()
+  }
+
+  const index = entries.findIndex((entry) => entry.slug === params.entrySlug)
+  if (index === -1) {
+    notFound()
+  }
+
+  const entry = entries[index]
+  const previous = index > 0 ? entries[index - 1] : undefined
+  const next = index < entries.length - 1 ? entries[index + 1] : undefined
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-8 px-4 py-16 text-slate-100">
+      <Link href={`/book/${book.slug}`} className="text-sm font-semibold text-cyan-300 hover:text-cyan-200">
+        ← Back to {book.title}
+      </Link>
+
+      <header className="space-y-2">
+        <h1 className="text-4xl font-bold text-cyan-100">{entry.title}</h1>
+        {entry.subtitle && <p className="text-lg text-slate-300">{entry.subtitle}</p>}
+        <time className="block text-sm uppercase tracking-wide text-slate-500">
+          {new Date(entry.publishedAt).toLocaleDateString()}
+        </time>
+      </header>
+
+      <WinterAdventureRenderer entry={entry} photos={photos} />
+
+      <nav className="flex flex-col gap-4 border-t border-slate-700 pt-6 text-sm text-cyan-200 sm:flex-row sm:justify-between">
+        {previous ? (
+          <Link href={`/book/${book.slug}/${previous.slug}`} className="hover:text-cyan-100">
+            ← {previous.title}
+          </Link>
+        ) : (
+          <span className="text-slate-500">Beginning of the chronicle</span>
+        )}
+        {next ? (
+          <Link href={`/book/${book.slug}/${next.slug}`} className="ml-auto hover:text-cyan-100">
+            {next.title} →
+          </Link>
+        ) : (
+          <span className="ml-auto text-slate-500">More chapters coming soon</span>
+        )}
+      </nav>
+    </div>
+  )
+}

--- a/src/app/(winter)/book/[bookSlug]/page.tsx
+++ b/src/app/(winter)/book/[bookSlug]/page.tsx
@@ -1,0 +1,65 @@
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { getWinterBook, getWinterEntriesForBook } from '@/lib/winter/store'
+
+interface PageProps {
+  params: {
+    bookSlug: string
+  }
+}
+
+export const revalidate = 0
+
+export default async function WinterBookPage({ params }: PageProps) {
+  const book = await getWinterBook(params.bookSlug)
+  if (!book) {
+    notFound()
+  }
+
+  const entries = await getWinterEntriesForBook(book.slug)
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-10 px-4 py-16 text-slate-100">
+      <header className="space-y-4 text-center">
+        <h1 className="text-5xl font-bold text-cyan-200">{book.title}</h1>
+        {book.description && <p className="text-lg text-slate-300">{book.description}</p>}
+      </header>
+
+      {entries.length === 0 ? (
+        <p className="text-center text-slate-400">No chapters recorded yet. Return soon!</p>
+      ) : (
+        <ul className="space-y-6">
+          {entries.map((entry) => (
+            <li
+              key={entry.id}
+              className="space-y-3 rounded-2xl border border-slate-700/60 bg-slate-900/60 p-6"
+            >
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-baseline sm:justify-between">
+                <div>
+                  <h2 className="text-3xl font-semibold text-slate-100">
+                    <Link href={`/book/${book.slug}/${entry.slug}`} className="hover:text-cyan-200">
+                      {entry.title}
+                    </Link>
+                  </h2>
+                  {entry.subtitle && <p className="text-sm text-slate-400">{entry.subtitle}</p>}
+                </div>
+                <time className="text-xs uppercase tracking-wide text-slate-500">
+                  {new Date(entry.publishedAt).toLocaleDateString()}
+                </time>
+              </div>
+              <p className="text-slate-300">{entry.excerpt}</p>
+              <div className="text-right">
+                <Link
+                  href={`/book/${book.slug}/${entry.slug}`}
+                  className="text-sm font-semibold text-cyan-300 hover:text-cyan-200"
+                >
+                  Continue reading →
+                </Link>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/app/(winter)/page.tsx
+++ b/src/app/(winter)/page.tsx
@@ -1,13 +1,40 @@
 'use client'
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import SnowWithAccumulation from "@/components/ui/SnowWithAccumulation";
+import type { WinterAdventureEntry } from '@/lib/winter/types';
 
 
 const PathSixHomepage = () => {
   const [hoveredCharacter, setHoveredCharacter] = useState<number | null>(null);
+  const [latestEntry, setLatestEntry] = useState<WinterAdventureEntry | null>(null);
+  const [loadingEntry, setLoadingEntry] = useState(true);
+
+  useEffect(() => {
+    async function loadLatestEntry() {
+      try {
+        const response = await fetch('/api/winter/adventure?book=snows-of-summer', {
+          cache: 'no-store',
+        });
+
+        if (!response.ok) {
+          return;
+        }
+
+        const data = await response.json();
+        const entries = (data.entries ?? []) as WinterAdventureEntry[];
+        if (entries.length > 0) {
+          setLatestEntry(entries[0]);
+        }
+      } finally {
+        setLoadingEntry(false);
+      }
+    }
+
+    loadLatestEntry();
+  }, []);
 
   const characters = [
     {
@@ -39,6 +66,14 @@ const PathSixHomepage = () => {
       description: "Scholar-warrior wielding faith and arcane knowledge"
     }
   ];
+
+  const adventureHref = latestEntry
+    ? `/book/${latestEntry.bookSlug}/${latestEntry.slug}`
+    : '/book/snows-of-summer';
+
+  const publishedLabel = latestEntry
+    ? new Date(latestEntry.publishedAt).toLocaleDateString()
+    : null;
 
   return (
     <div className="min-h-screen relative overflow-hidden">
@@ -104,7 +139,7 @@ const PathSixHomepage = () => {
           </div>
 
           <div className="ml-8 sm:ml-12 lg:ml-16 flex flex-col sm:flex-row items-start gap-6">
-            <Link href="/book/snows-of-summer">
+            <Link href={adventureHref}>
               <button className="group px-8 py-4 bg-gradient-to-r from-blue-600 to-purple-600 text-white rounded-lg hover:from-blue-700 hover:to-purple-700 transition-all duration-300 font-bold text-lg shadow-2xl hover:shadow-blue-500/25 hover:scale-105">
                 <span className="flex items-center">
                   Begin the Adventure
@@ -297,29 +332,31 @@ const PathSixHomepage = () => {
               {/* Adventure excerpt text */}
               <div className="flex-1">
                 <h3 className="text-2xl font-bold text-blue-200 mb-3">
-                  The Frozen Trail Beckons
+                  {latestEntry ? latestEntry.title : 'Our first winter tale arrives soon'}
                 </h3>
                 <p className="text-slate-400 text-sm mb-4">
-                  Posted on December 15th, 2024
+                  {loadingEntry
+                    ? 'Checking for the latest updates…'
+                    : latestEntry && publishedLabel
+                      ? `Posted on ${publishedLabel}`
+                      : 'No log entries have been published yet.'}
                 </p>
-                
+
                 <div className="prose prose-invert prose-lg max-w-none">
-                  <p className="text-slate-300 leading-relaxed mb-6">
-                    The icy wind howled through the ancient pines as our heroes pressed deeper into the cursed lands of Irrisen. What began as whispers of unnatural winter had become a bitter reality—snow fell where flowers should bloom, and the very air crackled with malevolent magic. Aelira&apos;s breath misted in the frigid air as she traced arcane symbols, seeking answers in the elemental forces that seemed to rebel against nature itself...
-                  </p>
-                  
-                  <blockquote className="border-l-4 border-blue-400 pl-6 py-2 bg-slate-700/30 rounded-r-lg my-6">
-                    <p className="text-blue-200 italic text-lg">
-                      &ldquo;The very stones here remember winter&rsquo;s eternal embrace. We tread where mortals were never meant to walk.&rdquo;
+                  {loadingEntry ? (
+                    <p className="text-slate-400">Loading excerpt…</p>
+                  ) : latestEntry ? (
+                    <p className="text-slate-300 leading-relaxed mb-6">{latestEntry.excerpt}</p>
+                  ) : (
+                    <p className="text-slate-400">
+                      The logbook is open and ready. Check back after our next session for the first full chapter of the
+                      Reign of Winter saga.
                     </p>
-                    <footer className="text-slate-400 text-sm mt-2">
-                      — Aelira Kaldren, upon sensing the ancient magics
-                    </footer>
-                  </blockquote>
+                  )}
                 </div>
 
                 <div className="flex flex-col sm:flex-row gap-4 mt-8">
-                  <Link href="/book/snows-of-summer">
+                  <Link href={adventureHref}>
                     <button className="group px-6 py-3 bg-gradient-to-r from-blue-600 to-purple-600 text-white rounded-lg hover:from-blue-700 hover:to-purple-700 transition-all duration-300 font-medium">
                       <span className="flex items-center">
                         Read the Full Adventure
@@ -329,8 +366,8 @@ const PathSixHomepage = () => {
                       </span>
                     </button>
                   </Link>
-                  
-                  <Link href="/book/snows-of-summer">
+
+                  <Link href="/adventure-log">
                     <button className="px-6 py-3 bg-slate-700/60 backdrop-blur-sm border border-slate-500/50 text-slate-200 rounded-lg hover:bg-slate-600/60 hover:border-blue-400/50 transition-all duration-300 font-medium">
                       View All Entries
                     </button>
@@ -367,7 +404,7 @@ const PathSixHomepage = () => {
             </p>
             
             <div className="flex flex-col sm:flex-row items-center justify-center gap-6">
-              <Link href="/book/snows-of-summer">
+              <Link href={adventureHref}>
                 <button className="group px-8 py-4 bg-gradient-to-r from-blue-600 to-purple-600 text-white rounded-lg hover:from-blue-700 hover:to-purple-700 transition-all duration-300 font-bold text-lg shadow-2xl hover:shadow-blue-500/25 hover:scale-105">
                   Start Reading
                 </button>

--- a/src/app/api/winter/adventure/[slug]/route.ts
+++ b/src/app/api/winter/adventure/[slug]/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server'
+import { auth } from '@clerk/nextjs/server'
+import { deleteWinterEntry, getWinterEntry, saveWinterEntry } from '@/lib/winter/store'
+
+export async function GET(_: Request, { params }: { params: { slug: string } }) {
+  const entry = await getWinterEntry(params.slug)
+  if (!entry) {
+    return new NextResponse('Not found', { status: 404 })
+  }
+
+  return NextResponse.json({ entry })
+}
+
+export async function PUT(request: Request, { params }: { params: { slug: string } }) {
+  const { userId } = auth()
+  if (!userId) {
+    return new NextResponse('Unauthorized', { status: 401 })
+  }
+
+  const payload = await request.json()
+  const existing = await getWinterEntry(params.slug)
+  if (!existing) {
+    return new NextResponse('Not found', { status: 404 })
+  }
+
+  const updated = {
+    ...existing,
+    title: typeof payload.title === 'string' ? payload.title : existing.title,
+    subtitle: typeof payload.subtitle === 'string' ? payload.subtitle : existing.subtitle,
+    excerpt: typeof payload.excerpt === 'string' ? payload.excerpt : existing.excerpt,
+    publishedAt: typeof payload.publishedAt === 'string' ? payload.publishedAt : existing.publishedAt,
+    content: payload.content ?? existing.content,
+    updatedAt: new Date().toISOString(),
+  }
+
+  await saveWinterEntry(updated)
+  return NextResponse.json({ entry: updated })
+}
+
+export async function DELETE(_: Request, { params }: { params: { slug: string } }) {
+  const { userId } = auth()
+  if (!userId) {
+    return new NextResponse('Unauthorized', { status: 401 })
+  }
+
+  const existing = await getWinterEntry(params.slug)
+  if (!existing) {
+    return new NextResponse('Not found', { status: 404 })
+  }
+
+  await deleteWinterEntry(params.slug)
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/winter/adventure/route.ts
+++ b/src/app/api/winter/adventure/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from 'next/server'
+import { auth } from '@clerk/nextjs/server'
+import { getWinterEntries, saveWinterEntry } from '@/lib/winter/store'
+import { WinterAdventureEntry } from '@/lib/winter/types'
+
+function slugify(value: string) {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+export async function GET(request: Request) {
+  const url = new URL(request.url)
+  const bookSlug = url.searchParams.get('book') ?? undefined
+  const entries = await getWinterEntries()
+
+  const filtered = bookSlug ? entries.filter((entry) => entry.bookSlug === bookSlug) : entries
+  return NextResponse.json({ entries: filtered })
+}
+
+export async function POST(request: Request) {
+  const { userId } = auth()
+  if (!userId) {
+    return new NextResponse('Unauthorized', { status: 401 })
+  }
+
+  const payload = await request.json()
+  const entry: WinterAdventureEntry = {
+    id: payload.id ?? crypto.randomUUID(),
+    slug: payload.slug ? String(payload.slug) : slugify(String(payload.title ?? 'entry')),
+    bookSlug: String(payload.bookSlug ?? ''),
+    title: String(payload.title ?? 'Untitled entry'),
+    subtitle: payload.subtitle ? String(payload.subtitle) : undefined,
+    publishedAt: payload.publishedAt
+      ? String(payload.publishedAt)
+      : new Date().toISOString(),
+    excerpt: String(payload.excerpt ?? ''),
+    content: payload.content,
+    updatedAt: new Date().toISOString(),
+  }
+
+  if (!entry.bookSlug) {
+    return new NextResponse('bookSlug is required', { status: 400 })
+  }
+
+  if (!entry.excerpt) {
+    return new NextResponse('excerpt is required', { status: 400 })
+  }
+
+  if (!entry.content) {
+    return new NextResponse('content is required', { status: 400 })
+  }
+
+  const saved = await saveWinterEntry(entry)
+  return NextResponse.json({ entry: saved }, { status: 201 })
+}

--- a/src/app/api/winter/photos/[id]/route.ts
+++ b/src/app/api/winter/photos/[id]/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server'
+import { auth } from '@clerk/nextjs/server'
+import { deleteWinterPhoto, getWinterPhoto, updateWinterPhoto } from '@/lib/winter/store'
+
+export async function PATCH(request: Request, { params }: { params: { id: string } }) {
+  const { userId } = auth()
+  if (!userId) {
+    return new NextResponse('Unauthorized', { status: 401 })
+  }
+
+  const payload = await request.json()
+  const updates = {
+    alt: typeof payload.alt === 'string' ? payload.alt : undefined,
+    caption: typeof payload.caption === 'string' ? payload.caption : undefined,
+    credit: typeof payload.credit === 'string' ? payload.credit : undefined,
+  }
+
+  try {
+    const photo = await updateWinterPhoto(params.id, updates)
+    return NextResponse.json({ photo })
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Failed to update photo'
+    return new NextResponse(message, { status: 404 })
+  }
+}
+
+export async function DELETE(_: Request, { params }: { params: { id: string } }) {
+  const { userId } = auth()
+  if (!userId) {
+    return new NextResponse('Unauthorized', { status: 401 })
+  }
+
+  const photo = await getWinterPhoto(params.id)
+  if (!photo) {
+    return new NextResponse('Not found', { status: 404 })
+  }
+
+  await deleteWinterPhoto(params.id)
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/winter/photos/route.ts
+++ b/src/app/api/winter/photos/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server'
+import { auth } from '@clerk/nextjs/server'
+import { addWinterPhoto, listWinterPhotos, persistUploadedPhoto } from '@/lib/winter/store'
+
+export async function GET() {
+  const photos = await listWinterPhotos()
+  return NextResponse.json({ photos })
+}
+
+export async function POST(request: Request) {
+  const { userId } = auth()
+  if (!userId) {
+    return new NextResponse('Unauthorized', { status: 401 })
+  }
+
+  const formData = await request.formData()
+  const file = formData.get('file')
+  const alt = String(formData.get('alt') ?? '').trim()
+  const caption = String(formData.get('caption') ?? '').trim()
+  const credit = String(formData.get('credit') ?? '').trim()
+
+  if (!file || !(file instanceof File)) {
+    return new NextResponse('Image file is required', { status: 400 })
+  }
+
+  if (!alt) {
+    return new NextResponse('Alt text is required', { status: 400 })
+  }
+
+  const relativePath = await persistUploadedPhoto(file)
+  const photo = await addWinterPhoto({
+    relativePath,
+    alt,
+    caption: caption || undefined,
+    credit: credit || undefined,
+  })
+
+  return NextResponse.json({ photo }, { status: 201 })
+}

--- a/src/app/editor/layout.tsx
+++ b/src/app/editor/layout.tsx
@@ -1,0 +1,25 @@
+import Link from 'next/link'
+import type { ReactNode } from 'react'
+
+export default function EditorLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <header className="border-b border-slate-800 bg-slate-900/80">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+          <Link href="/" className="text-lg font-semibold text-cyan-200">
+            PathSix Winter Editor
+          </Link>
+          <nav className="flex items-center gap-4 text-sm">
+            <Link href="/editor/winter/adventure" className="hover:text-cyan-200">
+              Adventure entries
+            </Link>
+            <Link href="/editor/winter/photos" className="hover:text-cyan-200">
+              Photo library
+            </Link>
+          </nav>
+        </div>
+      </header>
+      <main className="mx-auto max-w-6xl px-6 py-10">{children}</main>
+    </div>
+  )
+}

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation'
+
+export default function EditorIndex() {
+  redirect('/editor/winter/adventure')
+}

--- a/src/app/editor/winter/adventure/[slug]/page.tsx
+++ b/src/app/editor/winter/adventure/[slug]/page.tsx
@@ -1,0 +1,35 @@
+import { notFound } from 'next/navigation'
+import { WinterEntryForm } from '@/components/winter/editor/WinterEntryForm'
+import { getWinterBooks, getWinterEntry } from '@/lib/winter/store'
+
+interface PageProps {
+  params: {
+    slug: string
+  }
+}
+
+export const revalidate = 0
+
+export default async function EditWinterEntryPage({ params }: PageProps) {
+  const [entry, books] = await Promise.all([
+    getWinterEntry(params.slug),
+    getWinterBooks(),
+  ])
+
+  if (!entry) {
+    notFound()
+  }
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h1 className="text-3xl font-semibold text-cyan-100">Edit entry</h1>
+        <p className="text-sm text-slate-400">
+          Update the chapter, adjust excerpts, or fine-tune photo placements.
+        </p>
+      </header>
+
+      <WinterEntryForm books={books} initialEntry={entry} mode="edit" />
+    </div>
+  )
+}

--- a/src/app/editor/winter/adventure/new/page.tsx
+++ b/src/app/editor/winter/adventure/new/page.tsx
@@ -1,0 +1,21 @@
+import { WinterEntryForm } from '@/components/winter/editor/WinterEntryForm'
+import { getWinterBooks } from '@/lib/winter/store'
+
+export const revalidate = 0
+
+export default async function CreateWinterEntryPage() {
+  const books = await getWinterBooks()
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h1 className="text-3xl font-semibold text-cyan-100">Create a new entry</h1>
+        <p className="text-sm text-slate-400">
+          Draft a fresh chapter for the Reign of Winter adventure log.
+        </p>
+      </header>
+
+      <WinterEntryForm books={books} mode="create" />
+    </div>
+  )
+}

--- a/src/app/editor/winter/adventure/page.tsx
+++ b/src/app/editor/winter/adventure/page.tsx
@@ -1,0 +1,61 @@
+import Link from 'next/link'
+import { getWinterEntries } from '@/lib/winter/store'
+
+export const revalidate = 0
+
+export default async function WinterAdventureEditorIndex() {
+  const entries = await getWinterEntries()
+
+  return (
+    <div className="space-y-8">
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-3xl font-semibold text-cyan-100">Winter adventure log</h1>
+          <p className="text-sm text-slate-400">
+            Draft, edit, and publish chapters for the Reign of Winter campaign.
+          </p>
+        </div>
+        <Link
+          href="/editor/winter/adventure/new"
+          className="inline-flex items-center rounded bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500"
+        >
+          Create entry
+        </Link>
+      </header>
+
+      <section className="space-y-4">
+        {entries.length === 0 ? (
+          <p className="text-sm text-slate-400">No entries yet. Click “Create entry” to start your chronicle.</p>
+        ) : (
+          <ul className="divide-y divide-slate-800 rounded-lg border border-slate-800 bg-slate-900/60">
+            {entries.map((entry) => (
+              <li key={entry.id} className="flex flex-col gap-4 px-4 py-4 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <p className="text-sm uppercase tracking-wide text-slate-500">
+                    {new Date(entry.publishedAt).toLocaleDateString()} · {entry.bookSlug}
+                  </p>
+                  <h2 className="text-xl font-semibold text-slate-100">{entry.title}</h2>
+                  {entry.subtitle && <p className="text-sm text-slate-400">{entry.subtitle}</p>}
+                </div>
+                <div className="flex gap-2">
+                  <Link
+                    href={`/book/${entry.bookSlug}/${entry.slug}`}
+                    className="rounded border border-slate-700 px-3 py-1 text-sm text-slate-300 hover:border-cyan-400 hover:text-cyan-200"
+                  >
+                    View
+                  </Link>
+                  <Link
+                    href={`/editor/winter/adventure/${entry.slug}`}
+                    className="rounded bg-emerald-600 px-3 py-1 text-sm font-semibold text-white hover:bg-emerald-500"
+                  >
+                    Edit
+                  </Link>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/src/app/editor/winter/photos/page.tsx
+++ b/src/app/editor/winter/photos/page.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { useState } from 'react'
+import { WinterPhotoLibrary } from '@/components/winter/editor/WinterPhotoLibrary'
+
+export default function WinterPhotoManagerPage() {
+  const [message, setMessage] = useState<string | null>(null)
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h1 className="text-3xl font-semibold text-cyan-100">Winter photo library</h1>
+        <p className="text-sm text-slate-400">
+          Upload new photos, update captions, or copy tokens for use in your adventure entries.
+        </p>
+        {message && <p className="mt-2 text-sm text-emerald-400">{message}</p>}
+      </header>
+
+      <WinterPhotoLibrary
+        onSelect={async (photo) => {
+          try {
+            await navigator.clipboard.writeText(`{{photo:${photo.id}}}`)
+            setMessage(`Copied token {{photo:${photo.id}}} to clipboard.`)
+          } catch {
+            setMessage(`Token {{photo:${photo.id}}} selected. Copy it into the story where needed.`)
+          }
+        }}
+      />
+    </div>
+  )
+}

--- a/src/app/regent/adventure-log/page.tsx
+++ b/src/app/regent/adventure-log/page.tsx
@@ -128,7 +128,7 @@ export default function AdventureLogIndex() {
         </p>
         
         <div className="grid gap-8">
-          {adventureBooks.map((book, index) => (
+          {adventureBooks.map((book) => (
             <Link 
               key={book.slug}
               href={`/regent/adventure-log/${book.slug}`}

--- a/src/app/shackles/adventure-log/page.tsx
+++ b/src/app/shackles/adventure-log/page.tsx
@@ -171,7 +171,7 @@ export default function ShacklesAdventureIndex() {
         </p>
         
         <div className="grid gap-8">
-          {adventureBooks.map((book, index) => (
+          {adventureBooks.map((book) => (
             <Link 
               key={book.slug}
               href={`/shackles/adventure-log/${book.slug}`}

--- a/src/components/winter/adventure/WinterAdventureRenderer.tsx
+++ b/src/components/winter/adventure/WinterAdventureRenderer.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { useMemo } from 'react'
+import { renderWinterEntry } from '@/lib/winter/render'
+import { WinterAdventureEntry, WinterPhoto } from '@/lib/winter/types'
+
+interface Props {
+  entry: WinterAdventureEntry
+  photos: WinterPhoto[]
+}
+
+export function WinterAdventureRenderer({ entry, photos }: Props) {
+  const html = useMemo(() => renderWinterEntry(entry, photos), [entry, photos])
+
+  return (
+    <article className="prose prose-invert max-w-none">
+      <div
+        className="winter-entry-content space-y-6"
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    </article>
+  )
+}

--- a/src/components/winter/editor/WinterEntryEditor.tsx
+++ b/src/components/winter/editor/WinterEntryEditor.tsx
@@ -1,0 +1,116 @@
+'use client'
+
+import { forwardRef, useEffect, useImperativeHandle } from 'react'
+import { EditorContent, useEditor, type JSONContent, type Editor } from '@tiptap/react'
+import { winterEditorExtensions } from '@/lib/winter/extensions'
+
+interface Props {
+  value: JSONContent
+  onChange: (content: JSONContent) => void
+  onRequestPhoto: () => void
+}
+
+export interface WinterEntryEditorHandle {
+  insertPhotoToken: (photoId: string) => void
+}
+
+export const WinterEntryEditor = forwardRef<WinterEntryEditorHandle, Props>(
+  ({ value, onChange, onRequestPhoto }, ref) => {
+    const editor = useEditor({
+      extensions: winterEditorExtensions,
+      content: value,
+      editorProps: {
+        attributes: {
+          class:
+            'min-h-[400px] rounded-lg border border-slate-700 bg-slate-900/60 p-4 focus:outline-none',
+        },
+      },
+      onUpdate({ editor }) {
+        onChange(editor.getJSON())
+      },
+    })
+
+    useEffect(() => {
+      if (!editor) {
+        return
+      }
+
+      const current = editor.getJSON()
+      if (JSON.stringify(current) !== JSON.stringify(value)) {
+        editor.commands.setContent(value)
+      }
+    }, [editor, value])
+
+    useImperativeHandle(ref, () => ({
+      insertPhotoToken(photoId) {
+        if (!editor) return
+        editor.chain().focus().insertContent(`{{photo:${photoId}}}`).run()
+      },
+    }))
+
+    const applyMark = (command: (editor: Editor) => void) => () => {
+      if (!editor) return
+      command(editor)
+    }
+
+    return (
+      <div className="space-y-3">
+        <div className="flex flex-wrap items-center gap-2 rounded-md border border-slate-700 bg-slate-900/60 p-2">
+          <button
+            type="button"
+            onClick={applyMark((editor) => editor.chain().focus().toggleBold().run())}
+            className="rounded bg-slate-800 px-3 py-1 text-sm font-semibold text-slate-200 hover:bg-slate-700"
+          >
+            Bold
+          </button>
+          <button
+            type="button"
+            onClick={applyMark((editor) => editor.chain().focus().toggleItalic().run())}
+            className="rounded bg-slate-800 px-3 py-1 text-sm font-semibold text-slate-200 hover:bg-slate-700"
+          >
+            Italic
+          </button>
+          <button
+            type="button"
+            onClick={applyMark((editor) => editor.chain().focus().toggleBulletList().run())}
+            className="rounded bg-slate-800 px-3 py-1 text-sm font-semibold text-slate-200 hover:bg-slate-700"
+          >
+            Bullets
+          </button>
+          <button
+            type="button"
+            onClick={applyMark((editor) => editor.chain().focus().toggleOrderedList().run())}
+            className="rounded bg-slate-800 px-3 py-1 text-sm font-semibold text-slate-200 hover:bg-slate-700"
+          >
+            Numbers
+          </button>
+          <button
+            type="button"
+            onClick={applyMark((editor) => editor.chain().focus().toggleBlockquote().run())}
+            className="rounded bg-slate-800 px-3 py-1 text-sm font-semibold text-slate-200 hover:bg-slate-700"
+          >
+            Quote
+          </button>
+          <button
+            type="button"
+            onClick={applyMark((editor) => editor.chain().focus().setHorizontalRule().run())}
+            className="rounded bg-slate-800 px-3 py-1 text-sm font-semibold text-slate-200 hover:bg-slate-700"
+          >
+            Divider
+          </button>
+          <button
+            type="button"
+            onClick={() => onRequestPhoto()}
+            className="rounded bg-blue-600 px-3 py-1 text-sm font-semibold text-white hover:bg-blue-500"
+          >
+            Insert photo token
+          </button>
+        </div>
+
+        <EditorContent editor={editor} />
+      </div>
+    )
+  },
+)
+
+WinterEntryEditor.displayName = 'WinterEntryEditor'

--- a/src/components/winter/editor/WinterEntryForm.tsx
+++ b/src/components/winter/editor/WinterEntryForm.tsx
@@ -1,0 +1,265 @@
+'use client'
+
+import { useMemo, useRef, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import type { JSONContent } from '@tiptap/core'
+import { WinterEntryEditor, WinterEntryEditorHandle } from './WinterEntryEditor'
+import { WinterPhotoLibrary } from './WinterPhotoLibrary'
+import type { WinterAdventureBook, WinterAdventureEntry } from '@/lib/winter/types'
+
+interface Props {
+  books: WinterAdventureBook[]
+  initialEntry?: WinterAdventureEntry
+  mode: 'create' | 'edit'
+}
+
+const emptyContent: JSONContent = {
+  type: 'doc',
+  content: [
+    {
+      type: 'paragraph',
+      content: [
+        {
+          type: 'text',
+          text: '',
+        },
+      ],
+    },
+  ],
+}
+
+function toDatetimeLocal(isoString: string) {
+  const date = new Date(isoString)
+  date.setMinutes(date.getMinutes() - date.getTimezoneOffset())
+  return date.toISOString().slice(0, 16)
+}
+
+export function WinterEntryForm({ books, initialEntry, mode }: Props) {
+  const router = useRouter()
+  const editorRef = useRef<WinterEntryEditorHandle>(null)
+  const [bookSlug, setBookSlug] = useState(initialEntry?.bookSlug ?? books[0]?.slug ?? '')
+  const [title, setTitle] = useState(initialEntry?.title ?? '')
+  const [subtitle, setSubtitle] = useState(initialEntry?.subtitle ?? '')
+  const [excerpt, setExcerpt] = useState(initialEntry?.excerpt ?? '')
+  const [publishedAt, setPublishedAt] = useState(
+    toDatetimeLocal(initialEntry?.publishedAt ?? new Date().toISOString()),
+  )
+  const [content, setContent] = useState<JSONContent>(initialEntry?.content ?? emptyContent)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+
+  const photoTokens = useMemo(() => {
+    const text = JSON.stringify(content)
+    const matches = Array.from(text.matchAll(/\{\{photo:([a-zA-Z0-9_-]+)\}\}/g))
+    return Array.from(new Set(matches.map((match) => match[1])))
+  }, [content])
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setError(null)
+    setSuccess(null)
+
+    if (!bookSlug) {
+      setError('Select a book before saving your entry.')
+      return
+    }
+
+    if (!title.trim()) {
+      setError('Title is required')
+      return
+    }
+
+    if (!excerpt.trim()) {
+      setError('Add a short excerpt so the homepage and listings have a preview.')
+      return
+    }
+
+    setSaving(true)
+
+    try {
+      const payload = {
+        bookSlug,
+        title: title.trim(),
+        subtitle: subtitle.trim() || undefined,
+        excerpt: excerpt.trim(),
+        content,
+        publishedAt: new Date(publishedAt).toISOString(),
+      }
+
+      let response: Response
+
+      if (mode === 'create') {
+        response = await fetch('/api/winter/adventure', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(payload),
+        })
+      } else if (initialEntry) {
+        response = await fetch(`/api/winter/adventure/${initialEntry.slug}`, {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(payload),
+        })
+      } else {
+        throw new Error('Edit mode requires an initial entry')
+      }
+
+      if (!response.ok) {
+        const message = await response.text()
+        throw new Error(message || 'Failed to save entry')
+      }
+
+      const data = await response.json()
+      const entry = data.entry as WinterAdventureEntry
+
+      if (mode === 'create') {
+        router.replace(`/editor/winter/adventure/${entry.slug}`)
+        router.refresh()
+      } else {
+        setSuccess('Entry saved successfully.')
+        router.refresh()
+      }
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Failed to save entry'
+      setError(message)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="grid gap-8 lg:grid-cols-[2fr_1fr]">
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="flex flex-col text-sm text-slate-300">
+            Adventure volume
+            <select
+              value={bookSlug}
+              onChange={(event) => setBookSlug(event.target.value)}
+              className="mt-1 rounded border border-slate-700 bg-slate-900/80 p-2"
+              required
+            >
+              <option value="" disabled>
+                Select a book
+              </option>
+              {books.map((book) => (
+                <option key={book.slug} value={book.slug}>
+                  {book.title}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col text-sm text-slate-300">
+            Published at
+            <input
+              type="datetime-local"
+              value={publishedAt}
+              onChange={(event) => setPublishedAt(event.target.value)}
+              className="mt-1 rounded border border-slate-700 bg-slate-900/80 p-2"
+              required
+            />
+          </label>
+        </div>
+
+        <label className="flex flex-col text-sm text-slate-300">
+          Title
+          <input
+            type="text"
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+            className="mt-1 rounded border border-slate-700 bg-slate-900/80 p-2"
+            required
+          />
+        </label>
+
+        <label className="flex flex-col text-sm text-slate-300">
+          Subtitle
+          <input
+            type="text"
+            value={subtitle}
+            onChange={(event) => setSubtitle(event.target.value)}
+            className="mt-1 rounded border border-slate-700 bg-slate-900/80 p-2"
+            placeholder="Optional"
+          />
+        </label>
+
+        <label className="flex flex-col text-sm text-slate-300">
+          Excerpt
+          <textarea
+            value={excerpt}
+            onChange={(event) => setExcerpt(event.target.value)}
+            className="mt-1 h-32 rounded border border-slate-700 bg-slate-900/80 p-2"
+            required
+          />
+        </label>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-semibold text-slate-200">Story body</span>
+            <span className="text-xs text-slate-500">
+              Insert photo tokens where you want images to appear: <code>{'{{photo:your-photo-id}}'}</code>
+            </span>
+          </div>
+          <WinterEntryEditor
+            ref={editorRef}
+            value={content}
+            onChange={setContent}
+            onRequestPhoto={() => {
+              document.getElementById('winter-photo-library')?.scrollIntoView({ behavior: 'smooth' })
+            }}
+          />
+        </div>
+
+        <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4">
+          <h3 className="text-sm font-semibold text-slate-200">Photo tokens in use</h3>
+          {photoTokens.length === 0 ? (
+            <p className="text-sm text-slate-500">No photos inserted yet.</p>
+          ) : (
+            <ul className="mt-2 flex flex-wrap gap-2 text-xs text-slate-200">
+              {photoTokens.map((token) => (
+                <li key={token} className="rounded border border-slate-700 bg-slate-800/80 px-2 py-1">
+                  {`{{photo:${token}}}`}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        {error && <p className="text-sm text-red-400">{error}</p>}
+        {success && <p className="text-sm text-emerald-400">{success}</p>}
+
+        <div className="flex justify-end gap-3">
+          <button
+            type="submit"
+            disabled={saving}
+            className="rounded bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-slate-600"
+          >
+            {saving ? 'Saving…' : mode === 'create' ? 'Create entry' : 'Save changes'}
+          </button>
+        </div>
+      </form>
+
+      <aside className="space-y-4">
+        <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4">
+          <h2 className="text-lg font-semibold text-cyan-200">Photo library</h2>
+          <p className="text-sm text-slate-400">
+            Upload new photos or update captions. Click “Insert into entry” to drop a token at the current cursor.
+          </p>
+          <div id="winter-photo-library" className="mt-4">
+            <WinterPhotoLibrary
+              onSelect={(photo) => {
+                editorRef.current?.insertPhotoToken(photo.id)
+                setSuccess(`Inserted photo token {{photo:${photo.id}}}`)
+              }}
+            />
+          </div>
+        </div>
+      </aside>
+    </div>
+  )
+}

--- a/src/components/winter/editor/WinterPhotoLibrary.tsx
+++ b/src/components/winter/editor/WinterPhotoLibrary.tsx
@@ -1,0 +1,284 @@
+'use client'
+
+import Image from 'next/image'
+import { FormEvent, useEffect, useMemo, useState } from 'react'
+import { WinterPhoto } from '@/lib/winter/types'
+
+interface Props {
+  onSelect: (photo: WinterPhoto) => void
+}
+
+async function fetchPhotos(): Promise<WinterPhoto[]> {
+  const response = await fetch('/api/winter/photos', { cache: 'no-store' })
+  if (!response.ok) {
+    throw new Error('Failed to load photos')
+  }
+
+  const data = await response.json()
+  return data.photos as WinterPhoto[]
+}
+
+export function WinterPhotoLibrary({ onSelect }: Props) {
+  const [photos, setPhotos] = useState<WinterPhoto[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [file, setFile] = useState<File | null>(null)
+  const [alt, setAlt] = useState('')
+  const [caption, setCaption] = useState('')
+  const [credit, setCredit] = useState('')
+  const [busyId, setBusyId] = useState<string | null>(null)
+
+  useEffect(() => {
+    async function load() {
+      try {
+        setLoading(true)
+        const items = await fetchPhotos()
+        setPhotos(items)
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : 'Failed to load photos'
+        setError(message)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    load()
+  }, [])
+
+  const sortedPhotos = useMemo(
+    () =>
+      [...photos].sort(
+        (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+      ),
+    [photos],
+  )
+
+  async function handleUpload(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (!file) {
+      setError('Select a file to upload')
+      return
+    }
+
+    try {
+      setError(null)
+      const formData = new FormData()
+      formData.set('file', file)
+      formData.set('alt', alt)
+      formData.set('caption', caption)
+      formData.set('credit', credit)
+
+      const response = await fetch('/api/winter/photos', {
+        method: 'POST',
+        body: formData,
+      })
+
+      if (!response.ok) {
+        throw new Error('Failed to upload photo')
+      }
+
+      const payload = await response.json()
+      setPhotos((current) => [payload.photo as WinterPhoto, ...current])
+      setFile(null)
+      setAlt('')
+      setCaption('')
+      setCredit('')
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Failed to upload photo'
+      setError(message)
+    }
+  }
+
+  async function handleMetadataSave(photo: WinterPhoto, updates: Partial<WinterPhoto>) {
+    try {
+      setBusyId(photo.id)
+      const response = await fetch(`/api/winter/photos/${photo.id}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(updates),
+      })
+
+      if (!response.ok) {
+        throw new Error('Failed to update photo metadata')
+      }
+
+      const payload = await response.json()
+      setPhotos((items) => items.map((item) => (item.id === photo.id ? (payload.photo as WinterPhoto) : item)))
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Failed to update photo'
+      setError(message)
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-lg border border-slate-700 bg-slate-900/60 p-4">
+        <h3 className="text-lg font-semibold text-slate-200">Add a new photo</h3>
+        <form onSubmit={handleUpload} className="mt-3 grid gap-3 md:grid-cols-2">
+          <label className="flex flex-col text-sm text-slate-300">
+            Image file
+            <input
+              type="file"
+              accept="image/*"
+              onChange={(event) => setFile(event.target.files?.[0] ?? null)}
+              className="mt-1 rounded border border-slate-700 bg-slate-800/80 p-2 text-sm"
+              required
+            />
+          </label>
+          <label className="flex flex-col text-sm text-slate-300">
+            Alt text
+            <input
+              type="text"
+              value={alt}
+              onChange={(event) => setAlt(event.target.value)}
+              className="mt-1 rounded border border-slate-700 bg-slate-800/80 p-2 text-sm"
+              placeholder="Describe the image"
+              required
+            />
+          </label>
+          <label className="flex flex-col text-sm text-slate-300">
+            Caption
+            <input
+              type="text"
+              value={caption}
+              onChange={(event) => setCaption(event.target.value)}
+              className="mt-1 rounded border border-slate-700 bg-slate-800/80 p-2 text-sm"
+              placeholder="Optional caption"
+            />
+          </label>
+          <label className="flex flex-col text-sm text-slate-300">
+            Credit
+            <input
+              type="text"
+              value={credit}
+              onChange={(event) => setCredit(event.target.value)}
+              className="mt-1 rounded border border-slate-700 bg-slate-800/80 p-2 text-sm"
+              placeholder="Optional credit"
+            />
+          </label>
+          <div className="md:col-span-2 flex justify-end">
+            <button
+              type="submit"
+              className="rounded bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-500"
+            >
+              Upload photo
+            </button>
+          </div>
+        </form>
+      </div>
+
+      {error && <p className="text-sm text-red-400">{error}</p>}
+
+      {loading ? (
+        <p className="text-sm text-slate-400">Loading photo library…</p>
+      ) : (
+        <ul className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {sortedPhotos.map((photo) => (
+            <li key={photo.id} className="space-y-3 rounded-lg border border-slate-700 bg-slate-900/60 p-4">
+              <div className="relative h-40 w-full overflow-hidden rounded">
+                <Image
+                  src={photo.relativePath}
+                  alt={photo.alt}
+                  fill
+                  className="object-cover"
+                  sizes="(min-width: 1280px) 320px, (min-width: 768px) 280px, 100vw"
+                />
+              </div>
+              <div className="space-y-2 text-sm text-slate-300">
+                <p className="font-semibold text-slate-100">{photo.alt}</p>
+                {photo.caption && <p className="text-slate-400">{photo.caption}</p>}
+                {photo.credit && <p className="text-xs text-slate-500">{photo.credit}</p>}
+                <p className="text-xs text-slate-500">Token: {`{{photo:${photo.id}}}`}</p>
+              </div>
+              <div className="space-y-2">
+                <button
+                  type="button"
+                  onClick={() => onSelect(photo)}
+                  className="w-full rounded bg-emerald-600 px-3 py-1 text-sm font-semibold text-white hover:bg-emerald-500"
+                >
+                  Insert into entry
+                </button>
+                <details className="rounded border border-slate-700 bg-slate-800/60">
+                  <summary className="cursor-pointer px-3 py-1 text-sm text-slate-200">Edit metadata</summary>
+                  <MetadataEditor
+                    photo={photo}
+                    busy={busyId === photo.id}
+                    onSave={handleMetadataSave}
+                  />
+                </details>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+interface MetadataEditorProps {
+  photo: WinterPhoto
+  busy: boolean
+  onSave: (photo: WinterPhoto, updates: Partial<WinterPhoto>) => void
+}
+
+function MetadataEditor({ photo, busy, onSave }: MetadataEditorProps) {
+  const [alt, setAlt] = useState(photo.alt)
+  const [caption, setCaption] = useState(photo.caption ?? '')
+  const [credit, setCredit] = useState(photo.credit ?? '')
+
+  useEffect(() => {
+    setAlt(photo.alt)
+    setCaption(photo.caption ?? '')
+    setCredit(photo.credit ?? '')
+  }, [photo])
+
+  return (
+    <form
+      className="space-y-2 px-3 py-2"
+      onSubmit={(event) => {
+        event.preventDefault()
+        onSave(photo, { alt, caption, credit })
+      }}
+    >
+      <label className="flex flex-col text-xs text-slate-400">
+        Alt text
+        <input
+          type="text"
+          value={alt}
+          onChange={(event) => setAlt(event.target.value)}
+          className="mt-1 rounded border border-slate-700 bg-slate-900/80 p-1 text-sm"
+          required
+        />
+      </label>
+      <label className="flex flex-col text-xs text-slate-400">
+        Caption
+        <input
+          type="text"
+          value={caption}
+          onChange={(event) => setCaption(event.target.value)}
+          className="mt-1 rounded border border-slate-700 bg-slate-900/80 p-1 text-sm"
+        />
+      </label>
+      <label className="flex flex-col text-xs text-slate-400">
+        Credit
+        <input
+          type="text"
+          value={credit}
+          onChange={(event) => setCredit(event.target.value)}
+          className="mt-1 rounded border border-slate-700 bg-slate-900/80 p-1 text-sm"
+        />
+      </label>
+      <button
+        type="submit"
+        disabled={busy}
+        className="w-full rounded bg-blue-600 px-3 py-1 text-sm font-semibold text-white hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-slate-600"
+      >
+        {busy ? 'Saving…' : 'Save changes'}
+      </button>
+    </form>
+  )
+}

--- a/src/lib/fs-utils.ts
+++ b/src/lib/fs-utils.ts
@@ -1,0 +1,44 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+
+export const projectRoot = process.cwd()
+
+export async function ensureDir(dirPath: string) {
+  await fs.mkdir(dirPath, { recursive: true })
+}
+
+export async function readJsonFile<T>(relativePath: string, defaultValue: T): Promise<T> {
+  const absolutePath = path.join(projectRoot, relativePath)
+
+  try {
+    const data = await fs.readFile(absolutePath, 'utf-8')
+    return JSON.parse(data) as T
+  } catch (error: unknown) {
+    const err = error as NodeJS.ErrnoException
+    if (err.code === 'ENOENT') {
+      await ensureDir(path.dirname(absolutePath))
+      await fs.writeFile(absolutePath, JSON.stringify(defaultValue, null, 2), 'utf-8')
+      return defaultValue
+    }
+
+    throw error
+  }
+}
+
+export async function writeJsonFile<T>(relativePath: string, data: T) {
+  const absolutePath = path.join(projectRoot, relativePath)
+  await ensureDir(path.dirname(absolutePath))
+  await fs.writeFile(absolutePath, JSON.stringify(data, null, 2), 'utf-8')
+}
+
+export function resolvePublicPath(relativePath: string) {
+  return path.join(projectRoot, 'public', relativePath)
+}
+
+export function toPublicUrl(relativePath: string) {
+  if (!relativePath.startsWith('/')) {
+    return `/${relativePath}`
+  }
+
+  return relativePath
+}

--- a/src/lib/winter/extensions.ts
+++ b/src/lib/winter/extensions.ts
@@ -1,0 +1,15 @@
+import StarterKit from '@tiptap/starter-kit'
+import Placeholder from '@tiptap/extension-placeholder'
+import Typography from '@tiptap/extension-typography'
+
+export const winterEditorExtensions = [
+  StarterKit.configure({
+    heading: {
+      levels: [2, 3, 4],
+    },
+  }),
+  Typography,
+  Placeholder.configure({
+    placeholder: 'Describe the next chapter of your winter saga…',
+  }),
+]

--- a/src/lib/winter/render.ts
+++ b/src/lib/winter/render.ts
@@ -1,0 +1,56 @@
+import { generateHTML } from '@tiptap/react'
+import { winterEditorExtensions } from './extensions'
+import { WinterAdventureEntry, WinterPhoto } from './types'
+
+const photoTokenRegex = /\{\{photo:([a-zA-Z0-9_-]+)\}\}/g
+
+function buildPhotoHtml(photo: WinterPhoto) {
+  const attributes = {
+    alt: photo.alt ?? '',
+    src: photo.relativePath,
+  }
+
+  const imgTag = `<img src="${attributes.src}" alt="${attributes.alt.replace(/"/g, '&quot;')}" class="w-full rounded-lg shadow-lg" loading="lazy" />`
+  const captionParts: string[] = []
+
+  if (photo.caption) {
+    captionParts.push(photo.caption)
+  }
+
+  if (photo.credit) {
+    captionParts.push(`<span class="block text-xs text-slate-400">${photo.credit}</span>`)
+  }
+
+  const captionHtml = captionParts.length
+    ? `<figcaption class="mt-2 text-sm text-slate-300">${captionParts.join(' ')}</figcaption>`
+    : ''
+
+  return `<figure class="my-8">${imgTag}${captionHtml}</figure>`
+}
+
+export function renderWinterEntry(entry: WinterAdventureEntry, photos: WinterPhoto[]) {
+  const html = generateHTML(entry.content, winterEditorExtensions)
+
+  const expanded = html.replace(photoTokenRegex, (_, photoId: string) => {
+    const photo = photos.find((item) => item.id === photoId)
+    if (!photo) {
+      return ''
+    }
+
+    return buildPhotoHtml(photo)
+  })
+
+  return expanded
+}
+
+export function extractPhotoIds(entry: WinterAdventureEntry) {
+  const ids = new Set<string>()
+  const text = JSON.stringify(entry.content)
+  let match: RegExpExecArray | null
+
+  while ((match = photoTokenRegex.exec(text))) {
+    ids.add(match[1])
+  }
+
+  return Array.from(ids)
+}

--- a/src/lib/winter/store.ts
+++ b/src/lib/winter/store.ts
@@ -1,0 +1,182 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+import { readJsonFile, writeJsonFile, resolvePublicPath, ensureDir, toPublicUrl } from '../fs-utils'
+import {
+  WinterAdventureBook,
+  WinterAdventureEntry,
+  WinterBookCollection,
+  WinterEntryCollection,
+  WinterPhoto,
+  WinterPhotoLibrary,
+} from './types'
+
+const BOOKS_PATH = 'content/winter/books.json'
+const ENTRIES_PATH = 'content/winter/entries.json'
+const PHOTOS_PATH = 'content/winter/photos.json'
+
+async function readBooks(): Promise<WinterBookCollection> {
+  return readJsonFile<WinterBookCollection>(BOOKS_PATH, { books: [] })
+}
+
+async function readEntries(): Promise<WinterEntryCollection> {
+  return readJsonFile<WinterEntryCollection>(ENTRIES_PATH, { entries: [] })
+}
+
+async function readPhotos(): Promise<WinterPhotoLibrary> {
+  return readJsonFile<WinterPhotoLibrary>(PHOTOS_PATH, { photos: [] })
+}
+
+export async function getWinterBooks(): Promise<WinterAdventureBook[]> {
+  const { books } = await readBooks()
+  return books
+}
+
+export async function getWinterBook(slug: string): Promise<WinterAdventureBook | undefined> {
+  const { books } = await readBooks()
+  return books.find((book) => book.slug === slug)
+}
+
+export async function getWinterEntries(): Promise<WinterAdventureEntry[]> {
+  const { entries } = await readEntries()
+  return entries.sort(
+    (a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime(),
+  )
+}
+
+export async function getWinterEntriesForBook(bookSlug: string) {
+  const entries = await getWinterEntries()
+  return entries.filter((entry) => entry.bookSlug === bookSlug)
+}
+
+export async function getWinterEntry(slug: string) {
+  const { entries } = await readEntries()
+  return entries.find((entry) => entry.slug === slug)
+}
+
+export async function saveWinterEntry(entry: WinterAdventureEntry) {
+  const collection = await readEntries()
+  const existingIndex = collection.entries.findIndex((item) => item.id === entry.id || item.slug === entry.slug)
+  const now = new Date().toISOString()
+
+  if (!entry.updatedAt) {
+    entry.updatedAt = now
+  }
+
+  if (existingIndex >= 0) {
+    collection.entries[existingIndex] = { ...entry, updatedAt: now }
+  } else {
+    collection.entries.push({ ...entry, updatedAt: now })
+  }
+
+  await writeJsonFile(ENTRIES_PATH, collection)
+  return entry
+}
+
+export async function deleteWinterEntry(idOrSlug: string) {
+  const collection = await readEntries()
+  collection.entries = collection.entries.filter(
+    (entry) => entry.id !== idOrSlug && entry.slug !== idOrSlug,
+  )
+  await writeJsonFile(ENTRIES_PATH, collection)
+}
+
+export async function listWinterPhotos(): Promise<WinterPhoto[]> {
+  const { photos } = await readPhotos()
+  return photos.sort((a, b) => (a.createdAt > b.createdAt ? -1 : 1))
+}
+
+export async function getWinterPhoto(id: string) {
+  const { photos } = await readPhotos()
+  return photos.find((photo) => photo.id === id)
+}
+
+export interface AddPhotoInput {
+  id?: string
+  relativePath: string
+  alt: string
+  caption?: string
+  credit?: string
+}
+
+export async function addWinterPhoto(input: AddPhotoInput) {
+  const library = await readPhotos()
+  const existing = input.id ? library.photos.find((photo) => photo.id === input.id) : undefined
+  const now = new Date().toISOString()
+  const id = existing?.id ?? input.id ?? crypto.randomUUID()
+
+  const photo: WinterPhoto = {
+    id,
+    relativePath: toPublicUrl(input.relativePath),
+    alt: input.alt,
+    caption: input.caption,
+    credit: input.credit,
+    createdAt: existing?.createdAt ?? now,
+    updatedAt: now,
+  }
+
+  if (existing) {
+    const index = library.photos.findIndex((item) => item.id === existing.id)
+    library.photos[index] = photo
+  } else {
+    library.photos.push(photo)
+  }
+
+  await writeJsonFile(PHOTOS_PATH, library)
+  return photo
+}
+
+export async function updateWinterPhoto(id: string, payload: Partial<Omit<WinterPhoto, 'id' | 'createdAt'>>) {
+  const library = await readPhotos()
+  const index = library.photos.findIndex((photo) => photo.id === id)
+
+  if (index < 0) {
+    throw new Error(`Photo ${id} not found`)
+  }
+
+  const current = library.photos[index]
+  const updated: WinterPhoto = {
+    ...current,
+    ...payload,
+    relativePath: payload.relativePath ? toPublicUrl(payload.relativePath) : current.relativePath,
+    updatedAt: new Date().toISOString(),
+  }
+
+  library.photos[index] = updated
+  await writeJsonFile(PHOTOS_PATH, library)
+  return updated
+}
+
+export async function deleteWinterPhoto(id: string) {
+  const library = await readPhotos()
+  const index = library.photos.findIndex((photo) => photo.id === id)
+  if (index < 0) {
+    return
+  }
+
+  const [photo] = library.photos.splice(index, 1)
+  await writeJsonFile(PHOTOS_PATH, library)
+
+  const relative = photo.relativePath.startsWith('/') ? photo.relativePath.slice(1) : photo.relativePath
+  const absolutePath = resolvePublicPath(relative)
+
+  try {
+    await fs.unlink(absolutePath)
+  } catch (error: unknown) {
+    const err = error as NodeJS.ErrnoException
+    if (err.code !== 'ENOENT') {
+      throw error
+    }
+  }
+}
+
+export async function persistUploadedPhoto(file: File, fileName?: string) {
+  const arrayBuffer = await file.arrayBuffer()
+  const buffer = Buffer.from(arrayBuffer)
+  const safeName = fileName ?? `${crypto.randomUUID()}-${file.name}`.replace(/\s+/g, '-')
+  const uploadsDir = path.join('public', 'uploads', 'winter')
+  await ensureDir(path.join(process.cwd(), uploadsDir))
+  const absolute = path.join(process.cwd(), uploadsDir, safeName)
+  await fs.writeFile(absolute, buffer)
+  const relative = `/uploads/winter/${safeName}`
+  return relative
+}

--- a/src/lib/winter/types.ts
+++ b/src/lib/winter/types.ts
@@ -1,0 +1,42 @@
+import { JSONContent } from '@tiptap/core'
+
+export interface WinterAdventureBook {
+  slug: string
+  title: string
+  description?: string
+  coverImage?: string
+}
+
+export interface WinterAdventureEntry {
+  id: string
+  slug: string
+  bookSlug: string
+  title: string
+  subtitle?: string
+  publishedAt: string
+  excerpt: string
+  content: JSONContent
+  updatedAt?: string
+}
+
+export interface WinterPhoto {
+  id: string
+  relativePath: string
+  alt: string
+  caption?: string
+  credit?: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface WinterPhotoLibrary {
+  photos: WinterPhoto[]
+}
+
+export interface WinterEntryCollection {
+  entries: WinterAdventureEntry[]
+}
+
+export interface WinterBookCollection {
+  books: WinterAdventureBook[]
+}


### PR DESCRIPTION
## Summary
- add file-backed winter adventure, photo, and book data along with store helpers and render utilities
- introduce authenticated API routes and editor UI for creating, updating, and listing winter adventure entries plus managing photo uploads
- surface the new winter adventure log, book, and entry pages and hook the home page excerpt up to the latest entry

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d899694c708330a45047ea731a97fa