### PR TITLE
feat(tracker): font size zoom controls on character page

### DIFF
--- a/src/app/wrath/tracker/[characterId]/page.tsx
+++ b/src/app/wrath/tracker/[characterId]/page.tsx
@@ -10,11 +10,32 @@ import type { CharacterDetail } from '@/lib/tracker/types'
 import { HpPanel } from '@/components/tracker/HpPanel'
 import { AbilityGrid } from '@/components/tracker/AbilityGrid'
 
+const ZOOM_LEVELS = [0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.35]
+const ZOOM_DEFAULT_INDEX = 3
+const ZOOM_LS_KEY = 'tracker-zoom-index'
+
 export default function CharacterPage() {
   const { characterId } = useParams<{ characterId: string }>()
   const [detail, setDetail] = useState<CharacterDetail | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [zoomIndex, setZoomIndex] = useState(ZOOM_DEFAULT_INDEX)
+
+  useEffect(() => {
+    const saved = localStorage.getItem(ZOOM_LS_KEY)
+    if (saved !== null) {
+      const idx = parseInt(saved, 10)
+      if (idx >= 0 && idx < ZOOM_LEVELS.length) setZoomIndex(idx)
+    }
+  }, [])
+
+  function changeZoom(delta: number) {
+    setZoomIndex((prev) => {
+      const next = Math.max(0, Math.min(ZOOM_LEVELS.length - 1, prev + delta))
+      localStorage.setItem(ZOOM_LS_KEY, String(next))
+      return next
+    })
+  }
 
   const load = useCallback(async () => {
     setError(null)
@@ -45,7 +66,7 @@ export default function CharacterPage() {
   if (error || !detail) {
     return (
       <main className="min-h-screen bg-stone-dark text-parchment font-spectral p-8">
-        <Link href="/wrath/tracker" className="text-wotr-gold underline">
+        <Link href="/wrath/tracker" className="text-sm text-wotr-gold underline">
           ← Back to roster
         </Link>
         <div className="mt-4 p-3 rounded border border-abyssal-red/60 bg-abyssal-red/20">
@@ -57,13 +78,33 @@ export default function CharacterPage() {
 
   return (
     <main className="min-h-screen bg-stone-dark text-parchment font-spectral">
-      <div className="px-4 pt-4">
+      <div className="px-4 pt-4 flex items-center justify-between">
         <Link href="/wrath/tracker" className="text-sm text-wotr-gold/80 hover:text-wotr-gold underline">
           ← Roster
         </Link>
+        <div className="flex items-center gap-1" title="Adjust text size">
+          <button
+            onClick={() => changeZoom(-1)}
+            disabled={zoomIndex === 0}
+            className="w-7 h-7 flex items-center justify-center rounded border border-stone-light text-parchment/60 hover:text-parchment hover:border-wotr-gold/50 disabled:opacity-25 disabled:cursor-not-allowed text-sm font-cinzel leading-none"
+            aria-label="Decrease text size"
+          >
+            A−
+          </button>
+          <button
+            onClick={() => changeZoom(1)}
+            disabled={zoomIndex === ZOOM_LEVELS.length - 1}
+            className="w-7 h-7 flex items-center justify-center rounded border border-stone-light text-parchment/60 hover:text-parchment hover:border-wotr-gold/50 disabled:opacity-25 disabled:cursor-not-allowed text-base font-cinzel leading-none"
+            aria-label="Increase text size"
+          >
+            A+
+          </button>
+        </div>
       </div>
-      <HpPanel character={detail} onChanged={load} />
-      <AbilityGrid character={detail} onChanged={load} />
+      <div style={{ zoom: ZOOM_LEVELS[zoomIndex] }}>
+        <HpPanel character={detail} onChanged={load} />
+        <AbilityGrid character={detail} onChanged={load} />
+      </div>
     </main>
   )
 }


### PR DESCRIPTION
## Summary

- Adds **A− / A+** buttons in the top-right of the character page header
- Steps through 7 zoom levels: 70%, 80%, 90%, 100%, 110%, 120%, 135%
- Uses CSS `zoom` on the content wrapper (HpPanel + AbilityGrid), so text and boxes scale together with no Tailwind class changes
- Preference is saved to `localStorage` (`tracker-zoom-index`) and restored on next visit
- The controls themselves sit outside the zoomed area so they stay reachable at any scale

## Test plan

- [ ] Visit `/wrath/tracker/<characterId>` and click A+ several times — confirm text and card boxes grow together
- [ ] Click A− — confirm they shrink
- [ ] Verify buttons are disabled at the smallest and largest extremes
- [ ] Reload the page — confirm zoom level is restored from localStorage
- [ ] Navigate away and back — confirm preference persists

https://claude.ai/code/session_0125u9e8Krg6c858yU9q5WWu

---
_Generated by [Claude Code](https://claude.ai/code/session_0125u9e8Krg6c858yU9q5WWu)_