### PR TITLE
feat(tracker): zoom controls on all pages + reset button

### DIFF
--- a/src/app/wrath/tracker/[characterId]/page.tsx
+++ b/src/app/wrath/tracker/[characterId]/page.tsx
@@ -9,33 +9,15 @@ import { useParams } from 'next/navigation'
 import type { CharacterDetail } from '@/lib/tracker/types'
 import { HpPanel } from '@/components/tracker/HpPanel'
 import { AbilityGrid } from '@/components/tracker/AbilityGrid'
-
-const ZOOM_LEVELS = [0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.35]
-const ZOOM_DEFAULT_INDEX = 3
-const ZOOM_LS_KEY = 'tracker-zoom-index'
+import { ZoomControls } from '@/components/tracker/ZoomControls'
+import { useTrackerZoom } from '@/hooks/useTrackerZoom'
 
 export default function CharacterPage() {
   const { characterId } = useParams<{ characterId: string }>()
   const [detail, setDetail] = useState<CharacterDetail | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const [zoomIndex, setZoomIndex] = useState(ZOOM_DEFAULT_INDEX)
-
-  useEffect(() => {
-    const saved = localStorage.getItem(ZOOM_LS_KEY)
-    if (saved !== null) {
-      const idx = parseInt(saved, 10)
-      if (idx >= 0 && idx < ZOOM_LEVELS.length) setZoomIndex(idx)
-    }
-  }, [])
-
-  function changeZoom(delta: number) {
-    setZoomIndex((prev) => {
-      const next = Math.max(0, Math.min(ZOOM_LEVELS.length - 1, prev + delta))
-      localStorage.setItem(ZOOM_LS_KEY, String(next))
-      return next
-    })
-  }
+  const zoom = useTrackerZoom()
 
   const load = useCallback(async () => {
     setError(null)
@@ -82,26 +64,15 @@ export default function CharacterPage() {
         <Link href="/wrath/tracker" className="text-sm text-wotr-gold/80 hover:text-wotr-gold underline">
           ← Roster
         </Link>
-        <div className="flex items-center gap-1" title="Adjust text size">
-          <button
-            onClick={() => changeZoom(-1)}
-            disabled={zoomIndex === 0}
-            className="w-7 h-7 flex items-center justify-center rounded border border-stone-light text-parchment/60 hover:text-parchment hover:border-wotr-gold/50 disabled:opacity-25 disabled:cursor-not-allowed text-sm font-cinzel leading-none"
-            aria-label="Decrease text size"
-          >
-            A−
-          </button>
-          <button
-            onClick={() => changeZoom(1)}
-            disabled={zoomIndex === ZOOM_LEVELS.length - 1}
-            className="w-7 h-7 flex items-center justify-center rounded border border-stone-light text-parchment/60 hover:text-parchment hover:border-wotr-gold/50 disabled:opacity-25 disabled:cursor-not-allowed text-base font-cinzel leading-none"
-            aria-label="Increase text size"
-          >
-            A+
-          </button>
-        </div>
+        <ZoomControls
+          isMin={zoom.isMin}
+          isMax={zoom.isMax}
+          isDefault={zoom.isDefault}
+          onChange={zoom.change}
+          onReset={zoom.reset}
+        />
       </div>
-      <div style={{ zoom: ZOOM_LEVELS[zoomIndex] }}>
+      <div style={{ zoom: zoom.zoom }}>
         <HpPanel character={detail} onChanged={load} />
         <AbilityGrid character={detail} onChanged={load} />
       </div>

--- a/src/app/wrath/tracker/gm/page.tsx
+++ b/src/app/wrath/tracker/gm/page.tsx
@@ -12,6 +12,8 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import type { Character, Condition, Party, ResourcePool } from '@/lib/tracker/types'
+import { ZoomControls } from '@/components/tracker/ZoomControls'
+import { useTrackerZoom } from '@/hooks/useTrackerZoom'
 
 interface DashboardCharacter extends Character {
   conditions: Condition[]
@@ -40,6 +42,7 @@ export default function GmDashboardPage() {
   const [deleteConfirm, setDeleteConfirm] = useState(false)
   const [deleting, setDeleting] = useState(false)
   const pollTimer = useRef<ReturnType<typeof setInterval> | null>(null)
+  const zoom = useTrackerZoom()
 
   // Load parties on mount, filter to GM-owned (we need user_id for that)
   const loadParties = useCallback(async () => {
@@ -161,6 +164,7 @@ export default function GmDashboardPage() {
 
   return (
     <main className="min-h-screen bg-stone-dark text-parchment font-spectral">
+      <div style={{ zoom: zoom.zoom }}>
       <div className="mx-auto max-w-7xl px-6 py-8">
         <div className="flex items-baseline justify-between mb-6">
           <div>
@@ -169,27 +173,36 @@ export default function GmDashboardPage() {
             </Link>
             <h1 className="font-cinzel text-3xl text-wotr-gold mt-2">GM Dashboard</h1>
           </div>
-          <div className="text-right">
-            {parties.length > 1 ? (
-              <select
-                value={selectedPartyId ?? ''}
-                onChange={(e) => setSelectedPartyId(e.target.value)}
-                className="p-2 rounded bg-stone-dark border border-stone-light text-parchment"
-              >
-                {parties.map((p) => (
-                  <option key={p.id} value={p.id}>
-                    {p.name}
-                  </option>
-                ))}
-              </select>
-            ) : (
-              <div className="font-cinzel text-lg text-parchment">{dashboard?.party.name}</div>
-            )}
-            {lastRefresh && (
-              <div className="text-[10px] uppercase tracking-wider opacity-50 mt-1">
-                refreshed {lastRefresh.toLocaleTimeString()}
-              </div>
-            )}
+          <div className="flex items-start gap-3">
+            <ZoomControls
+              isMin={zoom.isMin}
+              isMax={zoom.isMax}
+              isDefault={zoom.isDefault}
+              onChange={zoom.change}
+              onReset={zoom.reset}
+            />
+            <div className="text-right">
+              {parties.length > 1 ? (
+                <select
+                  value={selectedPartyId ?? ''}
+                  onChange={(e) => setSelectedPartyId(e.target.value)}
+                  className="p-2 rounded bg-stone-dark border border-stone-light text-parchment"
+                >
+                  {parties.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.name}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <div className="font-cinzel text-lg text-parchment">{dashboard?.party.name}</div>
+              )}
+              {lastRefresh && (
+                <div className="text-[10px] uppercase tracking-wider opacity-50 mt-1">
+                  refreshed {lastRefresh.toLocaleTimeString()}
+                </div>
+              )}
+            </div>
           </div>
         </div>
 
@@ -249,6 +262,7 @@ export default function GmDashboardPage() {
             )}
           </div>
         )}
+      </div>
       </div>
     </main>
   )

--- a/src/app/wrath/tracker/page.tsx
+++ b/src/app/wrath/tracker/page.tsx
@@ -8,12 +8,15 @@ import Link from 'next/link'
 import type { Character } from '@/lib/tracker/types'
 import { NewCharacterModal } from '@/components/tracker/NewCharacterModal'
 import { PartiesSection } from '@/components/tracker/PartiesSection'
+import { ZoomControls } from '@/components/tracker/ZoomControls'
+import { useTrackerZoom } from '@/hooks/useTrackerZoom'
 
 export default function TrackerRosterPage() {
   const [characters, setCharacters] = useState<Character[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [creating, setCreating] = useState(false)
+  const zoom = useTrackerZoom()
 
   const load = useCallback(async () => {
     setError(null)
@@ -35,18 +38,28 @@ export default function TrackerRosterPage() {
 
   return (
     <main className="min-h-screen bg-stone-dark text-parchment font-spectral">
+      <div style={{ zoom: zoom.zoom }}>
       <div className="mx-auto max-w-5xl px-6 py-10">
         <header className="flex items-baseline justify-between mb-8 border-b border-stone-light pb-4">
           <div>
             <h1 className="font-cinzel text-3xl text-wotr-gold">Character Tracker</h1>
             <p className="text-sm opacity-70 mt-1">Your characters in this campaign.</p>
           </div>
-          <button
-            onClick={() => setCreating(true)}
-            className="px-4 py-2 rounded bg-wotr-gold/90 hover:bg-wotr-gold text-stone-dark font-semibold font-cinzel"
-          >
-            + New Character
-          </button>
+          <div className="flex items-center gap-3">
+            <ZoomControls
+              isMin={zoom.isMin}
+              isMax={zoom.isMax}
+              isDefault={zoom.isDefault}
+              onChange={zoom.change}
+              onReset={zoom.reset}
+            />
+            <button
+              onClick={() => setCreating(true)}
+              className="px-4 py-2 rounded bg-wotr-gold/90 hover:bg-wotr-gold text-stone-dark font-semibold font-cinzel"
+            >
+              + New Character
+            </button>
+          </div>
         </header>
 
         <PartiesSection />
@@ -109,6 +122,7 @@ export default function TrackerRosterPage() {
           }}
         />
       )}
+      </div>
     </main>
   )
 }

--- a/src/components/tracker/ZoomControls.tsx
+++ b/src/components/tracker/ZoomControls.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+interface Props {
+  isMin: boolean
+  isMax: boolean
+  isDefault: boolean
+  onChange: (delta: number) => void
+  onReset: () => void
+}
+
+export function ZoomControls({ isMin, isMax, isDefault, onChange, onReset }: Props) {
+  const btnBase =
+    'flex items-center justify-center rounded border border-stone-light text-parchment/60 hover:text-parchment hover:border-wotr-gold/50 disabled:opacity-25 disabled:cursor-not-allowed leading-none'
+
+  return (
+    <div className="flex items-center gap-1" title="Adjust text size">
+      <button
+        onClick={() => onChange(-1)}
+        disabled={isMin}
+        className={`w-7 h-7 text-sm font-cinzel ${btnBase}`}
+        aria-label="Decrease text size"
+      >
+        A−
+      </button>
+      <button
+        onClick={onReset}
+        disabled={isDefault}
+        className={`w-7 h-7 text-base ${btnBase}`}
+        aria-label="Reset text size to default"
+        title="Reset to default size"
+      >
+        ↺
+      </button>
+      <button
+        onClick={() => onChange(1)}
+        disabled={isMax}
+        className={`w-7 h-7 text-base font-cinzel ${btnBase}`}
+        aria-label="Increase text size"
+      >
+        A+
+      </button>
+    </div>
+  )
+}

--- a/src/hooks/useTrackerZoom.ts
+++ b/src/hooks/useTrackerZoom.ts
@@ -1,0 +1,42 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export const ZOOM_LEVELS = [0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.35]
+export const ZOOM_DEFAULT_INDEX = 3
+const LS_KEY = 'tracker-zoom-index'
+
+export function useTrackerZoom() {
+  const [index, setIndex] = useState(ZOOM_DEFAULT_INDEX)
+
+  useEffect(() => {
+    const saved = localStorage.getItem(LS_KEY)
+    if (saved !== null) {
+      const idx = parseInt(saved, 10)
+      if (idx >= 0 && idx < ZOOM_LEVELS.length) setIndex(idx)
+    }
+  }, [])
+
+  function change(delta: number) {
+    setIndex((prev) => {
+      const next = Math.max(0, Math.min(ZOOM_LEVELS.length - 1, prev + delta))
+      localStorage.setItem(LS_KEY, String(next))
+      return next
+    })
+  }
+
+  function reset() {
+    setIndex(ZOOM_DEFAULT_INDEX)
+    localStorage.setItem(LS_KEY, String(ZOOM_DEFAULT_INDEX))
+  }
+
+  return {
+    zoom: ZOOM_LEVELS[index],
+    index,
+    isDefault: index === ZOOM_DEFAULT_INDEX,
+    isMin: index === 0,
+    isMax: index === ZOOM_LEVELS.length - 1,
+    change,
+    reset,
+  }
+}


### PR DESCRIPTION
## Summary

- Extracts zoom logic into a shared `useTrackerZoom` hook (reads/writes `localStorage`)
- Extracts the controls into a reusable `ZoomControls` component
- Adds **A− / ↺ / A+** buttons to the **roster page** header (alongside "+ New Character") and the **GM dashboard** header (alongside the party selector)
- Adds a **↺ reset** button to all three pages — disabled when already at the default (100%) size
- All three pages share the same `localStorage` key, so changing zoom on one page persists across all of them

## Test plan

- [x] Roster: zoom in/out with A+/A−, confirm cards and text scale together
- [x] GM Dashboard: same check, confirm party cards scale
- [x] Character page: same check
- [x] ↺ button is greyed out at default size, clickable otherwise
- [x] Zoom preference survives page reload and navigating between pages

https://claude.ai/code/session_0125u9e8Krg6c858yU9q5WWu

---
_Generated by [Claude Code](https://claude.ai/code/session_0125u9e8Krg6c858yU9q5WWu)_