### PR TITLE
Add custom sections to the ability tracker

### DIFF
--- a/src/app/api/tracker/abilities/[id]/route.ts
+++ b/src/app/api/tracker/abilities/[id]/route.ts
@@ -17,7 +17,8 @@ const EDITABLE_FIELDS = [
   'recharge',
   'enabled',
   'hidden',
-  'sort_order'
+  'sort_order',
+  'section_id'
 ] as const
 
 export async function PATCH(req: NextRequest, ctx: Ctx) {

--- a/src/app/api/tracker/characters/[id]/abilities/route.ts
+++ b/src/app/api/tracker/characters/[id]/abilities/route.ts
@@ -16,6 +16,7 @@ interface CreateAbilityBody {
   uses_remaining?: number | null
   recharge?: Recharge
   sort_order?: number
+  section_id?: string | null
 }
 
 export async function GET(_req: NextRequest, ctx: Ctx) {
@@ -60,7 +61,8 @@ export async function POST(req: NextRequest, ctx: Ctx) {
       uses_max: body.uses_max ?? null,
       uses_remaining: body.uses_remaining ?? body.uses_max ?? null,
       recharge: body.recharge ?? null,
-      sort_order: body.sort_order ?? 0
+      sort_order: body.sort_order ?? 0,
+      section_id: body.section_id ?? null
     })
     .select()
     .single()

--- a/src/app/api/tracker/characters/[id]/merge/route.ts
+++ b/src/app/api/tracker/characters/[id]/merge/route.ts
@@ -110,6 +110,7 @@ export async function POST(req: NextRequest, ctx: Ctx) {
     drs: (d.damage_reduction as CharacterDetail['drs']) ?? [],
     resistances: (d.energy_resistance as CharacterDetail['resistances']) ?? [],
     vulnerabilities: (d.energy_vulnerability as CharacterDetail['vulnerabilities']) ?? [],
+    sections: [], // not part of the merge
     abilities: (d.ability as CharacterDetail['abilities']) ?? [],
     conditions: [], // not part of the merge
     pools: (d.resource_pool as CharacterDetail['pools']) ?? [],

--- a/src/app/api/tracker/characters/[id]/route.ts
+++ b/src/app/api/tracker/characters/[id]/route.ts
@@ -4,7 +4,7 @@ import { NextRequest } from 'next/server'
 import { supabase } from '@/lib/supabase'
 import { bad, fail, forbidden, json, notFound, requireCharacter } from '@/lib/tracker/http'
 import { isPartyMember } from '@/lib/tracker/auth'
-import type { Character, CharacterDetail } from '@/lib/tracker/types'
+import type { AbilitySection, Character, CharacterDetail } from '@/lib/tracker/types'
 
 type Ctx = { params: Promise<{ id: string }> }
 
@@ -49,6 +49,7 @@ export async function GET(_req: NextRequest, ctx: Ctx) {
       damage_reduction(*),
       energy_resistance(*),
       energy_vulnerability(*),
+      ability_section(*),
       ability(*),
       condition(*),
       resource_pool(*),
@@ -56,6 +57,7 @@ export async function GET(_req: NextRequest, ctx: Ctx) {
     `
     )
     .eq('id', id)
+    .order('sort_order', { referencedTable: 'ability_section', ascending: true })
     .order('sort_order', { referencedTable: 'ability', ascending: true })
     .order('applied_at', { referencedTable: 'condition', ascending: false })
     .order('sort_order', { referencedTable: 'resource_pool', ascending: true })
@@ -71,6 +73,7 @@ export async function GET(_req: NextRequest, ctx: Ctx) {
     damage_reduction,
     energy_resistance,
     energy_vulnerability,
+    ability_section,
     ability,
     condition,
     resource_pool,
@@ -80,6 +83,7 @@ export async function GET(_req: NextRequest, ctx: Ctx) {
     damage_reduction: CharacterDetail['drs']
     energy_resistance: CharacterDetail['resistances']
     energy_vulnerability: CharacterDetail['vulnerabilities']
+    ability_section: AbilitySection[]
     ability: CharacterDetail['abilities']
     condition: CharacterDetail['conditions']
     resource_pool: CharacterDetail['pools']
@@ -91,6 +95,7 @@ export async function GET(_req: NextRequest, ctx: Ctx) {
     drs: damage_reduction ?? [],
     resistances: energy_resistance ?? [],
     vulnerabilities: energy_vulnerability ?? [],
+    sections: ability_section ?? [],
     abilities: ability ?? [],
     conditions: condition ?? [],
     pools: resource_pool ?? [],

--- a/src/app/api/tracker/characters/[id]/sections/[sectionId]/route.ts
+++ b/src/app/api/tracker/characters/[id]/sections/[sectionId]/route.ts
@@ -1,0 +1,68 @@
+// Rename or delete a single ability section.
+// Abilities in a deleted section get section_id = null (ON DELETE SET NULL).
+
+import { NextRequest } from 'next/server'
+import { supabase } from '@/lib/supabase'
+import { bad, fail, json, notFound, requireCharacter } from '@/lib/tracker/http'
+import type { AbilitySection } from '@/lib/tracker/types'
+
+type Ctx = { params: Promise<{ id: string; sectionId: string }> }
+
+async function resolveSection(id: string, sectionId: string) {
+  const { data, error } = await supabase
+    .from('ability_section')
+    .select('*')
+    .eq('id', sectionId)
+    .eq('character_id', id)
+    .maybeSingle()
+  if (error) return { error: fail(error.message) }
+  if (!data) return { error: notFound('section') }
+  return { section: data as AbilitySection }
+}
+
+export async function PATCH(req: NextRequest, ctx: Ctx) {
+  const { id, sectionId } = await ctx.params
+  const auth = await requireCharacter(id, 'edit')
+  if ('error' in auth) return auth.error
+
+  const resolved = await resolveSection(id, sectionId)
+  if ('error' in resolved) return resolved.error
+
+  let body: { name?: string; sort_order?: number }
+  try {
+    body = (await req.json()) as { name?: string; sort_order?: number }
+  } catch {
+    return bad('invalid JSON body')
+  }
+
+  const patch: Record<string, unknown> = {}
+  if (body.name != null) {
+    if (!body.name.trim()) return bad('name cannot be blank')
+    patch.name = body.name.trim()
+  }
+  if (body.sort_order != null) patch.sort_order = body.sort_order
+  if (Object.keys(patch).length === 0) return bad('no editable fields supplied')
+
+  const { data, error } = await supabase
+    .from('ability_section')
+    .update(patch)
+    .eq('id', sectionId)
+    .select()
+    .single()
+
+  if (error || !data) return fail(error?.message ?? 'update failed')
+  return json({ section: data as AbilitySection })
+}
+
+export async function DELETE(_req: NextRequest, ctx: Ctx) {
+  const { id, sectionId } = await ctx.params
+  const auth = await requireCharacter(id, 'edit')
+  if ('error' in auth) return auth.error
+
+  const resolved = await resolveSection(id, sectionId)
+  if ('error' in resolved) return resolved.error
+
+  const { error } = await supabase.from('ability_section').delete().eq('id', sectionId)
+  if (error) return fail(error.message)
+  return json({ ok: true })
+}

--- a/src/app/api/tracker/characters/[id]/sections/route.ts
+++ b/src/app/api/tracker/characters/[id]/sections/route.ts
@@ -1,0 +1,60 @@
+// List + create ability sections for a character.
+
+import { NextRequest } from 'next/server'
+import { supabase } from '@/lib/supabase'
+import { bad, fail, json, requireCharacter } from '@/lib/tracker/http'
+import type { AbilitySection } from '@/lib/tracker/types'
+
+type Ctx = { params: Promise<{ id: string }> }
+
+export async function GET(_req: NextRequest, ctx: Ctx) {
+  const { id } = await ctx.params
+  const auth = await requireCharacter(id, 'view')
+  if ('error' in auth) return auth.error
+
+  const { data, error } = await supabase
+    .from('ability_section')
+    .select('*')
+    .eq('character_id', id)
+    .order('sort_order')
+    .order('created_at')
+
+  if (error) return fail(error.message)
+  return json({ sections: (data ?? []) as AbilitySection[] })
+}
+
+export async function POST(req: NextRequest, ctx: Ctx) {
+  const { id } = await ctx.params
+  const auth = await requireCharacter(id, 'edit')
+  if ('error' in auth) return auth.error
+
+  let body: { name?: string; sort_order?: number }
+  try {
+    body = (await req.json()) as { name?: string; sort_order?: number }
+  } catch {
+    return bad('invalid JSON body')
+  }
+
+  if (!body.name?.trim()) return bad('name is required')
+
+  // Default sort_order = current max + 10
+  let sortOrder = body.sort_order
+  if (sortOrder == null) {
+    const { data: existing } = await supabase
+      .from('ability_section')
+      .select('sort_order')
+      .eq('character_id', id)
+      .order('sort_order', { ascending: false })
+      .limit(1)
+    sortOrder = ((existing?.[0]?.sort_order as number | undefined) ?? 0) + 10
+  }
+
+  const { data, error } = await supabase
+    .from('ability_section')
+    .insert({ character_id: id, name: body.name.trim(), sort_order: sortOrder })
+    .select()
+    .single()
+
+  if (error || !data) return fail(error?.message ?? 'insert failed')
+  return json({ section: data as AbilitySection }, { status: 201 })
+}

--- a/src/components/tracker/AbilityEditModal.tsx
+++ b/src/components/tracker/AbilityEditModal.tsx
@@ -4,12 +4,14 @@ import { useState } from 'react'
 import type {
   Ability,
   AbilityCategory,
+  AbilitySection,
   ActionType,
   Recharge
 } from '@/lib/tracker/types'
 
 interface Props {
   characterId: string
+  sections: AbilitySection[]
   ability?: Ability
   /** Next available sort_order, used when creating. */
   nextSortOrder?: number
@@ -46,7 +48,7 @@ const RECHARGE_OPTIONS: { value: Recharge | ''; label: string }[] = [
   { value: 'manual', label: 'manual' }
 ]
 
-export function AbilityEditModal({ characterId, ability, nextSortOrder, onClose, onSaved }: Props) {
+export function AbilityEditModal({ characterId, sections, ability, nextSortOrder, onClose, onSaved }: Props) {
   const isNew = !ability
   const [name, setName] = useState(ability?.name ?? '')
   const [category, setCategory] = useState<AbilityCategory>(ability?.category ?? 'class_feature')
@@ -57,6 +59,7 @@ export function AbilityEditModal({ characterId, ability, nextSortOrder, onClose,
     ability?.uses_remaining != null ? String(ability.uses_remaining) : ''
   )
   const [recharge, setRecharge] = useState<Recharge | ''>(ability?.recharge ?? '')
+  const [sectionId, setSectionId] = useState<string>(ability?.section_id ?? '')
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [deleteConfirm, setDeleteConfirm] = useState(false)
@@ -94,7 +97,8 @@ export function AbilityEditModal({ characterId, ability, nextSortOrder, onClose,
         description: description.trim() || null,
         uses_max: max,
         uses_remaining: remaining,
-        recharge: recharge || null
+        recharge: recharge || null,
+        section_id: sectionId || null
       }
       if (isNew) {
         body.sort_order = nextSortOrder ?? 0
@@ -190,6 +194,24 @@ export function AbilityEditModal({ characterId, ability, nextSortOrder, onClose,
               </select>
             </label>
           </div>
+
+          {sections.length > 0 && (
+            <label className="block">
+              <span className="block text-sm opacity-80 mb-1">Section</span>
+              <select
+                value={sectionId}
+                onChange={(e) => setSectionId(e.target.value)}
+                className="w-full p-2 rounded bg-stone-dark border border-stone-light text-parchment"
+              >
+                <option value="">— Unsorted —</option>
+                {sections.map((s) => (
+                  <option key={s.id} value={s.id}>
+                    {s.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
 
           <label className="block">
             <span className="block text-sm opacity-80 mb-1">Description</span>

--- a/src/components/tracker/AbilityGrid.tsx
+++ b/src/components/tracker/AbilityGrid.tsx
@@ -18,7 +18,7 @@ import {
   useSortable
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import type { Ability, AbilityCategory, ActionType, CharacterDetail } from '@/lib/tracker/types'
+import type { Ability, AbilityCategory, AbilitySection, ActionType, CharacterDetail } from '@/lib/tracker/types'
 import { AbilityEditModal } from './AbilityEditModal'
 import { SpellsModal } from './SpellsModal'
 
@@ -55,8 +55,6 @@ async function setHidden(abilityId: string, hidden: boolean) {
   })
 }
 
-/** After a drag, renumber the affected section's items to clean multiples of 10
- *  (10, 20, 30, …). Only PATCH the ones whose sort_order actually changed. */
 async function applyReorder(reordered: Ability[]) {
   const updates = reordered
     .map((item, i) => ({ id: item.id, oldOrder: item.sort_order, newOrder: (i + 1) * 10 }))
@@ -78,27 +76,71 @@ export function AbilityGrid({ character, onChanged }: Props) {
   const [creating, setCreating] = useState(false)
   const [editing, setEditing] = useState<Ability | null>(null)
   const [spellsOpen, setSpellsOpen] = useState(false)
+  const [newSectionName, setNewSectionName] = useState('')
+  const [addingSectionOpen, setAddingSectionOpen] = useState(false)
+  const [savingSection, setSavingSection] = useState(false)
+  const [renamingId, setRenamingId] = useState<string | null>(null)
+  const [renameValue, setRenameValue] = useState('')
+  const [deletingId, setDeletingId] = useState<string | null>(null)
 
   const visible = character.abilities.filter((a) => !a.hidden)
   const hidden = character.abilities.filter((a) => a.hidden)
 
-  const limited = visible.filter((a) => a.uses_max != null)
-  const unlimited = visible.filter((a) => a.uses_max == null && a.action_type !== 'passive')
-  const passive = visible.filter((a) => a.action_type === 'passive')
+  const nextSortOrder = character.abilities.reduce((m, a) => Math.max(m, a.sort_order), 0) + 10
 
-  const nextSortOrder =
-    character.abilities.reduce((m, a) => Math.max(m, a.sort_order), 0) + 10
+  async function createSection() {
+    if (!newSectionName.trim()) return
+    setSavingSection(true)
+    try {
+      await fetch(`/api/tracker/characters/${character.id}/sections`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: newSectionName.trim() })
+      })
+      setNewSectionName('')
+      setAddingSectionOpen(false)
+      await onChanged()
+    } finally {
+      setSavingSection(false)
+    }
+  }
+
+  async function renameSection(sectionId: string, name: string) {
+    if (!name.trim()) return
+    await fetch(`/api/tracker/characters/${character.id}/sections/${sectionId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: name.trim() })
+    })
+    setRenamingId(null)
+    await onChanged()
+  }
+
+  async function deleteSection(sectionId: string) {
+    await fetch(`/api/tracker/characters/${character.id}/sections/${sectionId}`, {
+      method: 'DELETE'
+    })
+    setDeletingId(null)
+    await onChanged()
+  }
 
   return (
     <section className="flex-1 overflow-auto p-6">
-      <div className="flex items-center justify-between mb-4 gap-3">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4 gap-3 flex-wrap">
         <h3 className="font-cinzel text-xl text-wotr-gold">Cool Stuff</h3>
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-3 flex-wrap">
           <span className="text-xs opacity-50">
             {character.abilities.length === 0
               ? 'no abilities yet'
               : `${visible.length} active${hidden.length > 0 ? ` · ${hidden.length} parked` : ''}`}
           </span>
+          <button
+            onClick={() => setAddingSectionOpen((o) => !o)}
+            className="px-3 py-1.5 rounded border border-stone-light text-parchment/70 hover:text-parchment hover:border-wotr-gold/50 text-sm font-cinzel"
+          >
+            + New Section
+          </button>
           <button
             onClick={() => setSpellsOpen(true)}
             className="px-3 py-1.5 rounded border border-wotr-gold/60 text-wotr-gold hover:bg-wotr-gold/20 text-sm font-cinzel"
@@ -114,28 +156,135 @@ export function AbilityGrid({ character, onChanged }: Props) {
         </div>
       </div>
 
-      {character.abilities.length === 0 ? (
+      {/* New-section form */}
+      {addingSectionOpen && (
+        <div className="mb-4 flex items-center gap-2">
+          <input
+            autoFocus
+            value={newSectionName}
+            onChange={(e) => setNewSectionName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') createSection()
+              if (e.key === 'Escape') { setAddingSectionOpen(false); setNewSectionName('') }
+            }}
+            placeholder="Section name…"
+            className="flex-1 max-w-xs p-2 rounded bg-stone-dark border border-stone-light text-parchment text-sm"
+          />
+          <button
+            onClick={createSection}
+            disabled={savingSection || !newSectionName.trim()}
+            className="px-3 py-2 rounded bg-wotr-gold/90 hover:bg-wotr-gold text-stone-dark font-semibold text-sm disabled:opacity-50"
+          >
+            {savingSection ? '…' : 'Add'}
+          </button>
+          <button
+            onClick={() => { setAddingSectionOpen(false); setNewSectionName('') }}
+            className="px-3 py-2 rounded border border-stone-light text-parchment/60 hover:text-parchment text-sm"
+          >
+            Cancel
+          </button>
+        </div>
+      )}
+
+      {character.abilities.length === 0 && character.sections.length === 0 ? (
         <div className="rounded border border-dashed border-stone-light p-8 text-center opacity-70">
           <div className="font-cinzel text-wotr-gold/70 mb-1">No abilities yet</div>
           <div className="text-sm">
-            Pick a template when you create a character to pre-fill the cards, or click{' '}
-            <span className="text-wotr-gold">+ New ability</span> to add one manually.
+            Click <span className="text-wotr-gold">+ New Section</span> to create a section, then{' '}
+            <span className="text-wotr-gold">+ New ability</span> to add cards.
           </div>
         </div>
       ) : (
         <div className="space-y-6">
-          {limited.length > 0 && (
-            <AbilitySection title="Limited use" items={limited} onEdit={setEditing} onChanged={onChanged} />
-          )}
-          {unlimited.length > 0 && (
-            <AbilitySection title="At will" items={unlimited} onEdit={setEditing} onChanged={onChanged} />
-          )}
-          {passive.length > 0 && (
-            <AbilitySection title="Reminders" items={passive} onEdit={setEditing} onChanged={onChanged} />
-          )}
+          {/* User-defined sections */}
+          {character.sections.map((sec) => {
+            const items = visible.filter((a) => a.section_id === sec.id)
+            return (
+              <div key={sec.id}>
+                {/* Section header with rename / delete */}
+                <div className="flex items-center gap-2 mb-2">
+                  {renamingId === sec.id ? (
+                    <input
+                      autoFocus
+                      value={renameValue}
+                      onChange={(e) => setRenameValue(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') renameSection(sec.id, renameValue)
+                        if (e.key === 'Escape') setRenamingId(null)
+                      }}
+                      onBlur={() => renameSection(sec.id, renameValue)}
+                      className="text-xs font-cinzel uppercase tracking-wider bg-stone-dark border border-wotr-gold/40 rounded px-2 py-0.5 text-parchment w-40"
+                    />
+                  ) : (
+                    <span className="text-xs uppercase tracking-wider opacity-70 font-cinzel">{sec.name}</span>
+                  )}
+                  <button
+                    onClick={() => { setRenamingId(sec.id); setRenameValue(sec.name) }}
+                    className="text-parchment/30 hover:text-wotr-gold text-xs px-1"
+                    title="Rename section"
+                  >
+                    ✎
+                  </button>
+                  {deletingId === sec.id ? (
+                    <span className="flex items-center gap-1 text-xs">
+                      <span className="text-abyssal-red">Delete section?</span>
+                      <button
+                        onClick={() => deleteSection(sec.id)}
+                        className="px-2 py-0.5 rounded bg-abyssal-red text-parchment"
+                      >
+                        Yes
+                      </button>
+                      <button
+                        onClick={() => setDeletingId(null)}
+                        className="px-2 py-0.5 rounded border border-stone-light text-parchment/60"
+                      >
+                        No
+                      </button>
+                    </span>
+                  ) : (
+                    <button
+                      onClick={() => setDeletingId(sec.id)}
+                      className="text-parchment/20 hover:text-abyssal-red text-xs px-1"
+                      title="Delete section (abilities move to Unsorted)"
+                    >
+                      ✕
+                    </button>
+                  )}
+                </div>
+                {items.length === 0 ? (
+                  <div className="rounded border border-dashed border-stone-light/40 p-4 text-center text-xs opacity-50">
+                    No cards here — edit an ability and pick this section.
+                  </div>
+                ) : (
+                  <AbilitySectionGrid
+                    items={items}
+                    onEdit={setEditing}
+                    onChanged={onChanged}
+                  />
+                )}
+              </div>
+            )
+          })}
+
+          {/* Unsorted — abilities with no section */}
+          {(() => {
+            const unsorted = visible.filter((a) => a.section_id == null)
+            if (unsorted.length === 0 && character.sections.length > 0) return null
+            return (
+              <div>
+                {character.sections.length > 0 && (
+                  <div className="text-xs uppercase tracking-wider opacity-40 mb-2 font-cinzel">Unsorted</div>
+                )}
+                {unsorted.length === 0 ? null : (
+                  <AbilitySectionGrid items={unsorted} onEdit={setEditing} onChanged={onChanged} />
+                )}
+              </div>
+            )
+          })()}
         </div>
       )}
 
+      {/* Parked */}
       {hidden.length > 0 && (
         <div className="mt-8 pt-4 border-t border-stone-light">
           <button
@@ -159,6 +308,7 @@ export function AbilityGrid({ character, onChanged }: Props) {
       {creating && (
         <AbilityEditModal
           characterId={character.id}
+          sections={character.sections}
           nextSortOrder={nextSortOrder}
           onClose={() => setCreating(false)}
           onSaved={async () => {
@@ -170,6 +320,7 @@ export function AbilityGrid({ character, onChanged }: Props) {
       {editing && (
         <AbilityEditModal
           characterId={character.id}
+          sections={character.sections}
           ability={editing}
           onClose={() => setEditing(null)}
           onSaved={async () => {
@@ -190,22 +341,16 @@ export function AbilityGrid({ character, onChanged }: Props) {
   )
 }
 
-function AbilitySection({
-  title,
+function AbilitySectionGrid({
   items,
   onEdit,
   onChanged
 }: {
-  title: string
   items: Ability[]
   onEdit: (a: Ability) => void
   onChanged: () => void | Promise<void>
 }) {
-  // Local optimistic order — applied immediately on drop, then we sync with server.
-  // We re-derive from props on every render so server state wins after refetch.
   const sensors = useSensors(
-    // 5px movement before drag triggers — prevents accidental drags when clicking
-    // buttons (−1, +1, ✎, ✕).
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   )
@@ -222,18 +367,15 @@ function AbilitySection({
   }
 
   return (
-    <div>
-      <div className="text-xs uppercase tracking-wider opacity-50 mb-2 font-cinzel">{title}</div>
-      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-        <SortableContext items={items.map((a) => a.id)} strategy={rectSortingStrategy}>
-          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
-            {items.map((a) => (
-              <SortableAbilityCard key={a.id} ability={a} onEdit={onEdit} onChanged={onChanged} />
-            ))}
-          </div>
-        </SortableContext>
-      </DndContext>
-    </div>
+    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+      <SortableContext items={items.map((a) => a.id)} strategy={rectSortingStrategy}>
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
+          {items.map((a) => (
+            <SortableAbilityCard key={a.id} ability={a} onEdit={onEdit} onChanged={onChanged} />
+          ))}
+        </div>
+      </SortableContext>
+    </DndContext>
   )
 }
 

--- a/src/lib/tracker/types.ts
+++ b/src/lib/tracker/types.ts
@@ -142,9 +142,18 @@ export interface HpEvent {
   note: string | null
 }
 
+export interface AbilitySection {
+  id: string
+  character_id: string
+  name: string
+  sort_order: number
+  created_at: string
+}
+
 export interface Ability {
   id: string
   character_id: string
+  section_id: string | null
   name: string
   category: AbilityCategory
   action_type: ActionType | null
@@ -209,6 +218,7 @@ export interface CharacterDetail extends Character {
   drs: DamageReduction[]
   resistances: EnergyResistance[]
   vulnerabilities: EnergyVulnerability[]
+  sections: AbilitySection[]
   abilities: Ability[]
   conditions: Condition[]
   pools: ResourcePool[]

--- a/supabase/migrations/011_sections.sql
+++ b/supabase/migrations/011_sections.sql
@@ -1,0 +1,16 @@
+-- User-defined sections for ability cards (migration 011).
+-- Each character can have named sections; abilities get an optional section_id.
+-- Deleting a section sets section_id to null (abilities drop to "Unsorted").
+
+create table if not exists ability_section (
+  id           uuid primary key default gen_random_uuid(),
+  character_id uuid not null references character(id) on delete cascade,
+  name         text not null,
+  sort_order   integer not null default 0,
+  created_at   timestamptz not null default now()
+);
+create index if not exists ability_section_character_idx on ability_section (character_id, sort_order);
+
+alter table ability add column if not exists section_id uuid references ability_section(id) on delete set null;
+
+alter table ability_section enable row level security;


### PR DESCRIPTION
## Summary

- Players can create named sections for their Cool Stuff ability cards (e.g. "Combat Buffs", "Ki Powers", "Offense")
- Any card can be moved to any section via its edit modal — just pick a section from the new dropdown
- Section headers have inline rename (✎) and delete (✕) controls; deleting a section moves its cards to Unsorted automatically
- The old three hard-coded buckets (Limited use / At will / Reminders) are replaced by user sections + a catch-all Unsorted group at the bottom

## DB migration required

Run `supabase/migrations/011_sections.sql` in your Supabase SQL editor before deploying:

```sql
create table ability_section (id uuid primary key ..., character_id, name, sort_order);
alter table ability add column section_id uuid references ability_section(id) on delete set null;
```

## Test plan

- [ ] Create a new section — appears immediately above Unsorted
- [ ] Rename a section inline (click ✎, type, Enter or blur)
- [ ] Delete a section — its cards drop to Unsorted
- [ ] Edit an ability → Section dropdown shows all sections + "Unsorted" — pick one and save → card moves
- [ ] Drag reorder within a section still works
- [ ] Characters with no sections: Unsorted group renders as before (no section label shown)
- [ ] New ability created while sections exist can be assigned a section during creation

---
_Generated by [Claude Code](https://claude.ai/code/session_01GoKnn1s4nMTfyWwB2WNHYE)_