### PR TITLE
Section dropdown: show which auto-bucket a card returns to

### DIFF
--- a/src/components/tracker/AbilityEditModal.tsx
+++ b/src/components/tracker/AbilityEditModal.tsx
@@ -203,7 +203,14 @@ export function AbilityEditModal({ characterId, sections, ability, nextSortOrder
                 onChange={(e) => setSectionId(e.target.value)}
                 className="w-full p-2 rounded bg-stone-dark border border-stone-light text-parchment"
               >
-                <option value="">— Unsorted —</option>
+                <option value="">
+                  {(() => {
+                    const hasMax = usesMax.trim() !== '' && parseInt(usesMax, 10) > 0
+                    if (hasMax) return '← Auto-grouped: Limited use'
+                    if (actionType === 'passive') return '← Auto-grouped: Reminders'
+                    return '← Auto-grouped: At will'
+                  })()}
+                </option>
                 {sections.map((s) => (
                   <option key={s.id} value={s.id}>
                     {s.name}


### PR DESCRIPTION
## What changed

The top option in the Section dropdown now reads dynamically based on the card's current settings:

- Has uses → `← Auto-grouped: Limited use`
- Passive action → `← Auto-grouped: Reminders`
- Everything else → `← Auto-grouped: At will`

Picking it sets `section_id = null` and returns the card to the appropriate original bucket. No migration needed — frontend only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GoKnn1s4nMTfyWwB2WNHYE)_