### PR TITLE
Add multi-DC spell save entries (replaces single Spell DC field)

### DIFF
--- a/src/app/api/tracker/characters/[id]/merge/route.ts
+++ b/src/app/api/tracker/characters/[id]/merge/route.ts
@@ -114,7 +114,8 @@ export async function POST(req: NextRequest, ctx: Ctx) {
     abilities: (d.ability as CharacterDetail['abilities']) ?? [],
     conditions: [], // not part of the merge
     pools: (d.resource_pool as CharacterDetail['pools']) ?? [],
-    spells: (d.spell as CharacterDetail['spells']) ?? []
+    spells: (d.spell as CharacterDetail['spells']) ?? [],
+    spell_dc_entries: [] // not part of the merge
   }
 
   const plan = buildMergePlan(current, body.incoming)

--- a/src/app/api/tracker/characters/[id]/route.ts
+++ b/src/app/api/tracker/characters/[id]/route.ts
@@ -4,7 +4,7 @@ import { NextRequest } from 'next/server'
 import { supabase } from '@/lib/supabase'
 import { bad, fail, forbidden, json, notFound, requireCharacter } from '@/lib/tracker/http'
 import { isPartyMember } from '@/lib/tracker/auth'
-import type { AbilitySection, Character, CharacterDetail } from '@/lib/tracker/types'
+import type { AbilitySection, Character, CharacterDetail, SpellDcEntry } from '@/lib/tracker/types'
 
 type Ctx = { params: Promise<{ id: string }> }
 
@@ -53,7 +53,8 @@ export async function GET(_req: NextRequest, ctx: Ctx) {
       ability(*),
       condition(*),
       resource_pool(*),
-      spell(*)
+      spell(*),
+      spell_dc_entry(*)
     `
     )
     .eq('id', id)
@@ -63,6 +64,7 @@ export async function GET(_req: NextRequest, ctx: Ctx) {
     .order('sort_order', { referencedTable: 'resource_pool', ascending: true })
     .order('level', { referencedTable: 'spell', ascending: true })
     .order('name', { referencedTable: 'spell', ascending: true })
+    .order('sort_order', { referencedTable: 'spell_dc_entry', ascending: true })
     .single()
 
   if (error) return fail(error.message)
@@ -78,6 +80,7 @@ export async function GET(_req: NextRequest, ctx: Ctx) {
     condition,
     resource_pool,
     spell,
+    spell_dc_entry,
     ...character
   } = data as Character & {
     damage_reduction: CharacterDetail['drs']
@@ -88,6 +91,7 @@ export async function GET(_req: NextRequest, ctx: Ctx) {
     condition: CharacterDetail['conditions']
     resource_pool: CharacterDetail['pools']
     spell: CharacterDetail['spells']
+    spell_dc_entry: SpellDcEntry[]
   }
 
   const detail: CharacterDetail = {
@@ -99,7 +103,8 @@ export async function GET(_req: NextRequest, ctx: Ctx) {
     abilities: ability ?? [],
     conditions: condition ?? [],
     pools: resource_pool ?? [],
-    spells: spell ?? []
+    spells: spell ?? [],
+    spell_dc_entries: spell_dc_entry ?? []
   }
 
   return json({ character: detail })

--- a/src/app/api/tracker/characters/[id]/spell-dcs/route.ts
+++ b/src/app/api/tracker/characters/[id]/spell-dcs/route.ts
@@ -1,0 +1,75 @@
+// List + create spell DC entries on a character.
+
+import { NextRequest } from 'next/server'
+import { supabase } from '@/lib/supabase'
+import { bad, fail, json, requireCharacter } from '@/lib/tracker/http'
+import type { SpellDcEntry } from '@/lib/tracker/types'
+
+type Ctx = { params: Promise<{ id: string }> }
+
+interface CreateSpellDcBody {
+  name: string
+  dc: number
+  notes?: string
+  sort_order?: number
+}
+
+export async function GET(_req: NextRequest, ctx: Ctx) {
+  const { id } = await ctx.params
+  const auth = await requireCharacter(id, 'view')
+  if ('error' in auth) return auth.error
+
+  const { data, error } = await supabase
+    .from('spell_dc_entry')
+    .select('*')
+    .eq('character_id', id)
+    .order('sort_order')
+    .order('id')
+
+  if (error) return fail(error.message)
+  return json({ spell_dcs: (data ?? []) as SpellDcEntry[] })
+}
+
+export async function POST(req: NextRequest, ctx: Ctx) {
+  const { id } = await ctx.params
+  const auth = await requireCharacter(id, 'edit')
+  if ('error' in auth) return auth.error
+
+  let body: CreateSpellDcBody
+  try {
+    body = (await req.json()) as CreateSpellDcBody
+  } catch {
+    return bad('invalid JSON body')
+  }
+
+  if (!body.name?.trim()) return bad('name is required')
+  if (!Number.isFinite(body.dc)) return bad('dc must be a number')
+
+  // Default sort_order = current max + 10
+  let sortOrder = body.sort_order
+  if (sortOrder == null) {
+    const { data: maxRow } = await supabase
+      .from('spell_dc_entry')
+      .select('sort_order')
+      .eq('character_id', id)
+      .order('sort_order', { ascending: false })
+      .limit(1)
+      .single()
+    sortOrder = (maxRow?.sort_order ?? 0) + 10
+  }
+
+  const { data, error } = await supabase
+    .from('spell_dc_entry')
+    .insert({
+      character_id: id,
+      name: body.name.trim(),
+      dc: body.dc,
+      notes: body.notes?.trim() || null,
+      sort_order: sortOrder
+    })
+    .select()
+    .single()
+
+  if (error || !data) return fail(error?.message ?? 'insert failed')
+  return json({ spell_dc: data as SpellDcEntry }, { status: 201 })
+}

--- a/src/app/api/tracker/characters/route.ts
+++ b/src/app/api/tracker/characters/route.ts
@@ -144,5 +144,18 @@ export async function POST(req: NextRequest) {
     if (e) return fail(`pools: ${e.message}`)
   }
 
+  if (body.seed_spell_dcs?.length) {
+    const { error: e } = await supabase.from('spell_dc_entry').insert(
+      body.seed_spell_dcs.map((d, idx) => ({
+        character_id: character.id,
+        name: d.name,
+        dc: d.dc,
+        notes: d.notes ?? null,
+        sort_order: idx * 10
+      }))
+    )
+    if (e) return fail(`spell_dcs: ${e.message}`)
+  }
+
   return json({ character }, { status: 201 })
 }

--- a/src/app/api/tracker/parse-character-pdf/route.ts
+++ b/src/app/api/tracker/parse-character-pdf/route.ts
@@ -30,7 +30,7 @@ Schema:
   "ac": number | null,
   "ac_touch": number | null,
   "ac_flat_footed": number | null,
-  "spell_dc": number | null,          // single highest spell save DC (see SPELL DC rule); null if non-caster
+  "spell_dcs": [{ "name": string, "dc": number }],
   "mythic_path": string | null,       // mythic path name(s); dual path joined " / " (see MYTHIC rule); null if not mythic
   "mythic_tier": number | null,       // mythic tier 1-10 (see MYTHIC rule); null if not mythic
   "fortification_percent": number,    // 0 if none; light=25, moderate=50, heavy=75
@@ -95,14 +95,14 @@ SPELLS — every known and prepared spell.
 - school: lowercase like "evocation"; null if not in the PDF.
 - description: 1-2 sentences. Effect, save DC if applicable, range.
 
-SPELL DC (IMPORTANT) — this campaign uses a HOUSE RULE: every spell, at every
-level, uses the caster's single highest spell save DC. So report ONE number, not
-a DC per spell level. Compute it as the maximum spell save DC the character can
-produce: 10 + (the highest spell level they can cast) + (their relevant casting
-ability modifier). If the character has multiple casting classes, take the
-highest such DC across all of them. Hero Lab usually prints per-level save DCs in
-the spellcasting section — if so, just report the largest one you see. Set
-spell_dc to null only if the character has no spellcasting at all.
+SPELL DCS — extract every distinct spell save DC the character has.
+- Most casters have one DC per casting stat/class. Name it by school or class if situational.
+- This campaign uses a HOUSE RULE: every spell at every level uses the caster's highest DC per school/type. So report the maximum DC for each distinct context.
+- If the character has a single DC for all spells, output one entry: [{ "name": "Spell DC", "dc": N }].
+- If the character has multiple situational DCs (e.g. different by school, by class, or via feats like Spell Focus), output one entry per distinct DC, naming it descriptively: e.g. "Conjuration DC", "Enchantment DC", "Oracle DC".
+- Compute each DC as: 10 + (highest spell level they can cast with that class/school) + (relevant casting ability modifier).
+- Hero Lab usually prints per-level save DCs in the spellcasting section — use the largest value for each context.
+- Non-casters: output [].
 
 POOLS — resource pools that multiple abilities draw from (DIFFERENT from per-day ability uses):
 - Ki Pool (monk), Arcane Pool (magus), Grit (gunslinger), Panache (swashbuckler), Phrenic Pool (psychic), Mythic Power (mythic), Bardic Performance rounds (treat as pool OR ability — prefer pool if spent in increments).

--- a/src/app/api/tracker/spell-dcs/[id]/route.ts
+++ b/src/app/api/tracker/spell-dcs/[id]/route.ts
@@ -1,0 +1,67 @@
+// Single spell DC entry: PATCH (edit), DELETE.
+
+import { NextRequest } from 'next/server'
+import { supabase } from '@/lib/supabase'
+import { bad, fail, json, notFound, requireCharacter } from '@/lib/tracker/http'
+import type { SpellDcEntry } from '@/lib/tracker/types'
+
+type Ctx = { params: Promise<{ id: string }> }
+
+const EDITABLE_FIELDS = ['name', 'dc', 'notes', 'sort_order'] as const
+
+export async function PATCH(req: NextRequest, ctx: Ctx) {
+  const { id } = await ctx.params
+
+  // Look up entry to get character_id for auth check
+  const { data: entry, error: lookupErr } = await supabase
+    .from('spell_dc_entry')
+    .select('character_id')
+    .eq('id', id)
+    .single()
+  if (lookupErr || !entry) return notFound('spell_dc_entry')
+
+  const auth = await requireCharacter(entry.character_id as string, 'edit')
+  if ('error' in auth) return auth.error
+
+  let body: Partial<SpellDcEntry>
+  try {
+    body = (await req.json()) as Partial<SpellDcEntry>
+  } catch {
+    return bad('invalid JSON body')
+  }
+
+  const patch: Record<string, unknown> = {}
+  for (const key of EDITABLE_FIELDS) {
+    if (key in body) patch[key] = (body as Record<string, unknown>)[key]
+  }
+  if (Object.keys(patch).length === 0) return bad('no editable fields supplied')
+
+  const { data, error } = await supabase
+    .from('spell_dc_entry')
+    .update(patch)
+    .eq('id', id)
+    .select()
+    .single()
+
+  if (error || !data) return fail(error?.message ?? 'update failed')
+  return json({ spell_dc: data as SpellDcEntry })
+}
+
+export async function DELETE(_req: NextRequest, ctx: Ctx) {
+  const { id } = await ctx.params
+
+  // Look up entry to get character_id for auth check
+  const { data: entry, error: lookupErr } = await supabase
+    .from('spell_dc_entry')
+    .select('character_id')
+    .eq('id', id)
+    .single()
+  if (lookupErr || !entry) return notFound('spell_dc_entry')
+
+  const auth = await requireCharacter(entry.character_id as string, 'edit')
+  if ('error' in auth) return auth.error
+
+  const { error } = await supabase.from('spell_dc_entry').delete().eq('id', id)
+  if (error) return fail(error.message)
+  return json({ ok: true })
+}

--- a/src/components/tracker/CharacterEditModal.tsx
+++ b/src/components/tracker/CharacterEditModal.tsx
@@ -25,7 +25,6 @@ export function CharacterEditModal({ character, onClose, onSaved }: Props) {
   const [acFlatFooted, setAcFlatFooted] = useState(
     character.ac_flat_footed != null ? String(character.ac_flat_footed) : ''
   )
-  const [spellDc, setSpellDc] = useState(character.spell_dc != null ? String(character.spell_dc) : '')
   const [mythicPath, setMythicPath] = useState(character.mythic_path ?? '')
   const [mythicTier, setMythicTier] = useState(
     character.mythic_tier != null ? String(character.mythic_tier) : ''
@@ -99,7 +98,6 @@ export function CharacterEditModal({ character, onClose, onSaved }: Props) {
           ac: parseOptInt(ac),
           ac_touch: parseOptInt(acTouch),
           ac_flat_footed: parseOptInt(acFlatFooted),
-          spell_dc: parseOptInt(spellDc),
           mythic_path: mythicPath.trim() || null,
           mythic_tier: parseOptInt(mythicTier),
           deity: deity.trim() || null,
@@ -256,21 +254,7 @@ export function CharacterEditModal({ character, onClose, onSaved }: Props) {
             </div>
           </div>
 
-          <label className="block">
-            <span className="block text-sm opacity-80 mb-1 font-cinzel uppercase tracking-wider text-wotr-gold/80">
-              Spell DC
-            </span>
-            <input
-              type="number"
-              value={spellDc}
-              onChange={(e) => setSpellDc(e.target.value)}
-              className="tracker-input"
-              placeholder="—"
-            />
-            <span className="block text-xs opacity-50 mt-1">
-              House rule: one DC for every spell, all levels.
-            </span>
-          </label>
+          <div className="text-xs opacity-50">Spell DCs are managed in the Spell DCs panel on the character screen.</div>
 
           <div>
             <div className="text-sm opacity-80 mb-1 font-cinzel uppercase tracking-wider text-wotr-gold/80">

--- a/src/components/tracker/HpPanel.tsx
+++ b/src/components/tracker/HpPanel.tsx
@@ -6,6 +6,7 @@ import { DAMAGE_TYPES } from '@/lib/tracker/types'
 import { CharacterEditModal } from './CharacterEditModal'
 import { ConditionsBar } from './ConditionsBar'
 import { PoolsCard } from './PoolsCard'
+import { SpellDcsCard } from './SpellDcsCard'
 
 interface Props {
   character: CharacterDetail
@@ -102,11 +103,11 @@ export function HpPanel({ character, onChanged }: Props) {
     }
   }
 
-  // AC / Touch / FF / Spell DC live on the character row, so they go through the
+  // AC / Touch / FF live on the character row, so they go through the
   // character PATCH endpoint rather than the HP action route. The stepper updates
   // its own value optimistically and debounces the write; this reconciles to the
   // truth.
-  async function commitStat(field: 'ac' | 'ac_touch' | 'ac_flat_footed' | 'spell_dc', next: number) {
+  async function commitStat(field: 'ac' | 'ac_touch' | 'ac_flat_footed', next: number) {
     try {
       const res = await fetch(`/api/tracker/characters/${character.id}`, {
         method: 'PATCH',
@@ -346,18 +347,20 @@ export function HpPanel({ character, onChanged }: Props) {
           <AcStepper label="FF" value={character.ac_flat_footed} onCommit={(n) => commitStat('ac_flat_footed', n)} />
         </div>
 
-        {/* Spell DC — house rule: one DC for every spell at every level, so it
-            lives on the character like AC rather than per-spell. */}
-        <div className="px-4 py-3 rounded border border-wotr-gold/40 bg-stone-light/30 flex items-center justify-center">
-          <AcStepper label="Spell DC" value={character.spell_dc} large onCommit={(n) => commitStat('spell_dc', n)} />
-        </div>
-
         {/* Resource pools (Ki, Mythic Power, etc.) */}
         <PoolsCard
           characterId={character.id}
           pools={character.pools}
           onChanged={onChanged}
           className="min-w-[220px]"
+        />
+
+        {/* Spell DCs (named per school/class, house rule: use highest DC) */}
+        <SpellDcsCard
+          characterId={character.id}
+          spellDcs={character.spell_dc_entries}
+          onChanged={onChanged}
+          className="min-w-[180px]"
         />
 
         {/* Conditions (grows to fill remaining space) */}

--- a/src/components/tracker/NewCharacterModal.tsx
+++ b/src/components/tracker/NewCharacterModal.tsx
@@ -34,7 +34,6 @@ export function NewCharacterModal({ onClose, onCreated }: Props) {
   const [ac, setAc] = useState('')
   const [acTouch, setAcTouch] = useState('')
   const [acFlatFooted, setAcFlatFooted] = useState('')
-  const [spellDc, setSpellDc] = useState('')
   const [drs, setDrs] = useState<DrRow[]>([])
   const [resistances, setResistances] = useState<ResRow[]>([])
   const [vulnerabilities, setVulnerabilities] = useState<EnergyType[]>([])
@@ -45,10 +44,11 @@ export function NewCharacterModal({ onClose, onCreated }: Props) {
   const [parsing, setParsing] = useState(false)
   const [parseError, setParseError] = useState<string | null>(null)
   const [extracted, setExtracted] = useState<ExtractedCharacter | null>(null)
-  // Indices into extracted.{abilities,spells,pools} that the user wants to keep
+  // Indices into extracted.{abilities,spells,pools,spell_dcs} that the user wants to keep
   const [keptAbilityIdx, setKeptAbilityIdx] = useState<Set<number>>(new Set())
   const [keptSpellIdx, setKeptSpellIdx] = useState<Set<number>>(new Set())
   const [keptPoolIdx, setKeptPoolIdx] = useState<Set<number>>(new Set())
+  const [keptSpellDcIdx, setKeptSpellDcIdx] = useState<Set<number>>(new Set())
 
   // Template populate
   useEffect(() => {
@@ -62,7 +62,6 @@ export function NewCharacterModal({ onClose, onCreated }: Props) {
     if (p.ac != null) setAc(String(p.ac))
     if (p.ac_touch != null) setAcTouch(String(p.ac_touch))
     if (p.ac_flat_footed != null) setAcFlatFooted(String(p.ac_flat_footed))
-    if (p.spell_dc != null) setSpellDc(String(p.spell_dc))
     if (p.drs) setDrs(p.drs.map((d) => ({ amount: String(d.amount), bypass: d.bypass })))
     if (p.vulnerabilities) setVulnerabilities(p.vulnerabilities.map((v) => v.energy_type))
   }, [templateKey])
@@ -76,7 +75,6 @@ export function NewCharacterModal({ onClose, onCreated }: Props) {
     setAc(e.ac != null ? String(e.ac) : '')
     setAcTouch(e.ac_touch != null ? String(e.ac_touch) : '')
     setAcFlatFooted(e.ac_flat_footed != null ? String(e.ac_flat_footed) : '')
-    setSpellDc(e.spell_dc != null ? String(e.spell_dc) : '')
     setDrs((e.drs ?? []).map((d) => ({ amount: String(d.amount), bypass: d.bypass })))
     setResistances((e.resistances ?? []).map((r) => ({ energy_type: r.energy_type, amount: String(r.amount) })))
     setVulnerabilities((e.vulnerabilities ?? []).map((v) => v.energy_type))
@@ -84,6 +82,7 @@ export function NewCharacterModal({ onClose, onCreated }: Props) {
     setKeptAbilityIdx(new Set((e.abilities ?? []).map((_, i) => i)))
     setKeptSpellIdx(new Set((e.spells ?? []).map((_, i) => i)))
     setKeptPoolIdx(new Set((e.pools ?? []).map((_, i) => i)))
+    setKeptSpellDcIdx(new Set((e.spell_dcs ?? []).map((_, i) => i)))
   }
 
   async function parsePdf(file: File) {
@@ -125,6 +124,7 @@ export function NewCharacterModal({ onClose, onCreated }: Props) {
     setKeptAbilityIdx(new Set())
     setKeptSpellIdx(new Set())
     setKeptPoolIdx(new Set())
+    setKeptSpellDcIdx(new Set())
     lastPdfFile.current = null
     if (fileInputRef.current) fileInputRef.current.value = ''
   }
@@ -195,6 +195,12 @@ export function NewCharacterModal({ onClose, onCreated }: Props) {
             }))
         : undefined
 
+      const seedSpellDcs = extracted
+        ? extracted.spell_dcs
+            .map((d, i) => (keptSpellDcIdx.has(i) ? d : null))
+            .filter((d): d is NonNullable<typeof d> => d !== null)
+        : undefined
+
       const body = {
         name: name.trim(),
         class_summary: classSummary.trim() || undefined,
@@ -204,7 +210,6 @@ export function NewCharacterModal({ onClose, onCreated }: Props) {
         ac: parseOptInt(ac),
         ac_touch: parseOptInt(acTouch),
         ac_flat_footed: parseOptInt(acFlatFooted),
-        spell_dc: parseOptInt(spellDc),
         // DM-detail fields flow straight from the PDF parse (reviewable/editable
         // afterward in the character editor). null when created from a template
         // or by hand.
@@ -228,7 +233,8 @@ export function NewCharacterModal({ onClose, onCreated }: Props) {
         // PDF parse takes precedence over template if both were used
         seed_abilities: seedAbilitiesFromPdf ?? templateSeedAbilities,
         seed_spells: seedSpells,
-        seed_pools: seedPools
+        seed_pools: seedPools,
+        seed_spell_dcs: seedSpellDcs
       }
 
       const res = await fetch('/api/tracker/characters', {
@@ -400,16 +406,6 @@ export function NewCharacterModal({ onClose, onCreated }: Props) {
             </div>
           </div>
 
-          <Field label="Spell DC (optional)">
-            <input
-              type="number"
-              value={spellDc}
-              onChange={(e) => setSpellDc(e.target.value)}
-              className="tracker-input"
-              placeholder="—"
-            />
-          </Field>
-
           <div>
             <div className="flex items-center justify-between mb-1">
               <span className="text-sm opacity-80">Damage reduction</span>
@@ -580,11 +576,26 @@ export function NewCharacterModal({ onClose, onCreated }: Props) {
                 />
               )}
 
+              {extracted.spell_dcs.length > 0 && (
+                <ReviewSection
+                  title={`Spell DCs (${keptSpellDcIdx.size}/${extracted.spell_dcs.length})`}
+                  items={extracted.spell_dcs.map((d, i) => ({
+                    idx: i,
+                    label: d.name,
+                    sub: `DC ${d.dc}`,
+                    detail: null
+                  }))}
+                  keptSet={keptSpellDcIdx}
+                  onToggle={(i) => toggleKept(keptSpellDcIdx, setKeptSpellDcIdx, i)}
+                />
+              )}
+
               {extracted.abilities.length === 0 &&
                 extracted.spells.length === 0 &&
-                extracted.pools.length === 0 && (
+                extracted.pools.length === 0 &&
+                extracted.spell_dcs.length === 0 && (
                   <div className="text-sm opacity-60 italic">
-                    Parser extracted no abilities, spells, or pools from this PDF.
+                    Parser extracted no abilities, spells, pools, or spell DCs from this PDF.
                   </div>
                 )}
             </>

--- a/src/components/tracker/SpellDcsCard.tsx
+++ b/src/components/tracker/SpellDcsCard.tsx
@@ -1,0 +1,272 @@
+'use client'
+
+import { useState } from 'react'
+import type { SpellDcEntry } from '@/lib/tracker/types'
+
+interface Props {
+  characterId: string
+  spellDcs: SpellDcEntry[]
+  onChanged: () => void | Promise<void>
+  className?: string
+}
+
+export function SpellDcsCard({ characterId, spellDcs, onChanged, className }: Props) {
+  const [adding, setAdding] = useState(false)
+  const [editing, setEditing] = useState<SpellDcEntry | null>(null)
+
+  async function patchDc(entryId: string, delta: number) {
+    const entry = spellDcs.find((d) => d.id === entryId)
+    if (!entry) return
+    try {
+      const res = await fetch(`/api/tracker/spell-dcs/${entryId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ dc: entry.dc + delta })
+      })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        throw new Error(j.error ?? `HTTP ${res.status}`)
+      }
+      await onChanged()
+    } catch (e) {
+      console.error('spell dc patch failed', e)
+    }
+  }
+
+  return (
+    <div className={`p-3 rounded border border-stone-light bg-stone-light/20 ${className ?? ''}`}>
+      <div className="flex items-center justify-between mb-2">
+        <div className="text-xs uppercase tracking-wider font-cinzel opacity-70">Spell DCs</div>
+        <button onClick={() => setAdding(true)} className="text-xs text-wotr-gold hover:underline">
+          + Add DC
+        </button>
+      </div>
+
+      {spellDcs.length === 0 ? (
+        <div className="text-xs opacity-50 italic">No spell DCs.</div>
+      ) : (
+        <div className="space-y-1.5">
+          {spellDcs.map((d) => (
+            <div
+              key={d.id}
+              className="flex items-center gap-2 p-2 rounded border border-stone-light bg-stone-dark/40"
+            >
+              <button
+                onClick={() => setEditing(d)}
+                className="flex-1 min-w-0 text-left group"
+                title="Click to edit"
+              >
+                <div className="font-cinzel text-sm text-parchment group-hover:underline truncate">
+                  {d.name}
+                </div>
+                {d.notes && (
+                  <div className="text-[11px] italic opacity-60 truncate">{d.notes}</div>
+                )}
+              </button>
+              <div className="text-sm tabular-nums shrink-0">
+                <span className="text-wotr-gold font-bold">{d.dc}</span>
+              </div>
+              <div className="flex gap-1 shrink-0">
+                <button
+                  onClick={() => patchDc(d.id, -1)}
+                  className="px-1.5 py-0.5 text-xs rounded bg-abyssal-red/40 hover:bg-abyssal-red/60 text-parchment"
+                  title="Decrease DC by 1"
+                >
+                  −1
+                </button>
+                <button
+                  onClick={() => patchDc(d.id, 1)}
+                  className="px-1.5 py-0.5 text-xs rounded bg-emerald-900/40 hover:bg-emerald-900/60 text-parchment"
+                  title="Increase DC by 1"
+                >
+                  +1
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {adding && (
+        <SpellDcEditModal
+          characterId={characterId}
+          onClose={() => setAdding(false)}
+          onSaved={async () => {
+            setAdding(false)
+            await onChanged()
+          }}
+        />
+      )}
+      {editing && (
+        <SpellDcEditModal
+          characterId={characterId}
+          entry={editing}
+          onClose={() => setEditing(null)}
+          onSaved={async () => {
+            setEditing(null)
+            await onChanged()
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+interface SpellDcEditProps {
+  characterId: string
+  entry?: SpellDcEntry
+  onClose: () => void
+  onSaved: () => void | Promise<void>
+}
+
+function SpellDcEditModal({ characterId, entry, onClose, onSaved }: SpellDcEditProps) {
+  const isNew = !entry
+  const [name, setName] = useState(entry?.name ?? '')
+  const [dc, setDc] = useState(entry ? String(entry.dc) : '')
+  const [notes, setNotes] = useState(entry?.notes ?? '')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [deleteConfirm, setDeleteConfirm] = useState(false)
+
+  async function save() {
+    setError(null)
+    const dcNum = parseInt(dc, 10)
+    if (!name.trim()) return setError('Name is required.')
+    if (!Number.isFinite(dcNum)) return setError('DC must be a number.')
+
+    setSubmitting(true)
+    try {
+      const url = isNew
+        ? `/api/tracker/characters/${characterId}/spell-dcs`
+        : `/api/tracker/spell-dcs/${entry!.id}`
+      const method = isNew ? 'POST' : 'PATCH'
+      const body = {
+        name: name.trim(),
+        dc: dcNum,
+        notes: notes.trim() || null
+      }
+      const res = await fetch(url, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      })
+      const json = await res.json()
+      if (!res.ok) throw new Error(json.error ?? `HTTP ${res.status}`)
+      await onSaved()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+      setSubmitting(false)
+    }
+  }
+
+  async function remove() {
+    if (!entry) return
+    setSubmitting(true)
+    try {
+      const res = await fetch(`/api/tracker/spell-dcs/${entry.id}`, { method: 'DELETE' })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        throw new Error(j.error ?? `HTTP ${res.status}`)
+      }
+      await onSaved()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-stone-dark border border-wotr-gold/30 rounded-lg shadow-2xl p-6 w-full max-w-md"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="font-cinzel text-2xl text-wotr-gold mb-4">
+          {isNew ? 'New spell DC' : `Edit ${entry!.name}`}
+        </h2>
+
+        <div className="space-y-3">
+          <label className="block">
+            <span className="block text-sm opacity-80 mb-1">Name</span>
+            <input
+              autoFocus
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Spell DC, Conjuration DC, Oracle DC…"
+              className="w-full p-2 rounded bg-stone-dark border border-stone-light text-parchment"
+            />
+          </label>
+
+          <label className="block">
+            <span className="block text-sm opacity-80 mb-1">DC</span>
+            <input
+              type="number"
+              value={dc}
+              onChange={(e) => setDc(e.target.value)}
+              className="w-full p-2 rounded bg-stone-dark border border-stone-light text-parchment"
+            />
+          </label>
+
+          <label className="block">
+            <span className="block text-sm opacity-80 mb-1">Notes (optional)</span>
+            <input
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              placeholder="e.g. applies to all enchantment spells"
+              className="w-full p-2 rounded bg-stone-dark border border-stone-light text-parchment"
+            />
+          </label>
+
+          {error && <div className="text-abyssal-red text-sm">{error}</div>}
+        </div>
+
+        <div className="mt-6 flex items-center justify-between">
+          {!isNew &&
+            (!deleteConfirm ? (
+              <button
+                onClick={() => setDeleteConfirm(true)}
+                className="text-abyssal-red hover:text-abyssal-red/80 text-sm"
+              >
+                Delete DC
+              </button>
+            ) : (
+              <div className="flex items-center gap-2 text-sm">
+                <span className="text-abyssal-red">Sure?</span>
+                <button
+                  onClick={remove}
+                  disabled={submitting}
+                  className="px-3 py-1.5 rounded bg-abyssal-red text-parchment font-semibold text-xs"
+                >
+                  Delete
+                </button>
+                <button
+                  onClick={() => setDeleteConfirm(false)}
+                  className="text-parchment/60 hover:text-parchment text-xs"
+                >
+                  Cancel
+                </button>
+              </div>
+            ))}
+          <div className="flex gap-2 ml-auto">
+            <button
+              onClick={onClose}
+              className="px-4 py-2 text-sm rounded border border-stone-light hover:bg-stone-light/40"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={save}
+              disabled={submitting}
+              className="px-4 py-2 text-sm rounded bg-wotr-gold/90 hover:bg-wotr-gold text-stone-dark font-semibold disabled:opacity-50"
+            >
+              {submitting ? 'Saving…' : isNew ? 'Add' : 'Save'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/tracker/extracted.ts
+++ b/src/lib/tracker/extracted.ts
@@ -41,7 +41,7 @@ export interface ExtractedCharacter {
   ac: number | null
   ac_touch: number | null
   ac_flat_footed: number | null
-  spell_dc: number | null
+  spell_dcs: Array<{ name: string; dc: number }>
   mythic_path: string | null
   mythic_tier: number | null
   fortification_percent: number

--- a/src/lib/tracker/merge.test.ts
+++ b/src/lib/tracker/merge.test.ts
@@ -50,6 +50,7 @@ function detail(over: Partial<CharacterDetail> = {}): CharacterDetail {
     conditions: [],
     pools: [],
     spells: [],
+    spell_dc_entries: [],
     ...over
   }
 }
@@ -140,7 +141,7 @@ function extracted(over: Partial<ExtractedCharacter> = {}): ExtractedCharacter {
     ac: 20,
     ac_touch: 11,
     ac_flat_footed: 19,
-    spell_dc: null,
+    spell_dcs: [],
     mythic_path: null,
     mythic_tier: null,
     fortification_percent: 0,

--- a/src/lib/tracker/merge.ts
+++ b/src/lib/tracker/merge.ts
@@ -171,7 +171,6 @@ const SCALAR_FIELDS: Array<{ field: string; label: string }> = [
   { field: 'ac', label: 'AC' },
   { field: 'ac_touch', label: 'Touch' },
   { field: 'ac_flat_footed', label: 'Flat-Footed' },
-  { field: 'spell_dc', label: 'Spell DC' },
   { field: 'mythic_path', label: 'Mythic Path' },
   { field: 'mythic_tier', label: 'Mythic Tier' },
   { field: 'fortification_percent', label: 'Fortification %' },

--- a/src/lib/tracker/types.ts
+++ b/src/lib/tracker/types.ts
@@ -186,6 +186,15 @@ export interface ResourcePool {
   sort_order: number
 }
 
+export interface SpellDcEntry {
+  id: string
+  character_id: string
+  name: string
+  dc: number
+  notes: string | null
+  sort_order: number
+}
+
 export interface Spell {
   id: string
   character_id: string
@@ -223,6 +232,7 @@ export interface CharacterDetail extends Character {
   conditions: Condition[]
   pools: ResourcePool[]
   spells: Spell[]
+  spell_dc_entries: SpellDcEntry[]
 }
 
 export interface DamageRequest {
@@ -284,4 +294,5 @@ export interface CreateCharacterInput {
     recharge?: Recharge
     notes?: string
   }>
+  seed_spell_dcs?: Array<{ name: string; dc: number; notes?: string }>
 }

--- a/supabase/migrations/012_spell_dcs.sql
+++ b/supabase/migrations/012_spell_dcs.sql
@@ -1,0 +1,19 @@
+-- Multiple named spell DCs per character (migration 012).
+
+create table if not exists spell_dc_entry (
+  id           uuid primary key default gen_random_uuid(),
+  character_id uuid not null references character(id) on delete cascade,
+  name         text not null,
+  dc           integer not null,
+  notes        text,
+  sort_order   integer not null default 0
+);
+create index if not exists spell_dc_entry_character_idx on spell_dc_entry (character_id, sort_order);
+
+-- Seed from existing single spell_dc value so existing characters keep their number.
+insert into spell_dc_entry (character_id, name, dc, sort_order)
+select id, 'Spell DC', spell_dc, 0
+from character
+where spell_dc is not null;
+
+alter table spell_dc_entry enable row level security;


### PR DESCRIPTION
## Summary

Replaces the single "Spell DC" stepper with a full list of named spell DCs — same pattern as Resource Pools.

- Named DCs with `[name] [value] [−1] [+1]` display in the HP panel
- **+ Add DC** button opens a modal (name, DC value, optional notes)
- Click an entry to rename, change the value, or delete it
- PDF parser now extracts an array of named DCs (e.g. "Conjuration DC", "Enchantment DC") instead of one number — shows up in the PDF review checklist just like pools
- Existing characters: migration seeds their old `spell_dc` value into the new table as "Spell DC" automatically — no data lost

## DB migration required

Run `supabase/migrations/012_spell_dcs.sql` in Supabase SQL editor before deploying.

## Test plan

- [ ] Existing character: "Spell DC" entry appears (seeded from old value)
- [ ] `+ Add DC` → modal → enter name + value → saves and appears in list
- [ ] `−1` / `+1` buttons adjust the DC value
- [ ] Click entry name → edit modal → rename, change value, delete
- [ ] PDF parse → spell DCs appear in review checklist → unchecking skips them
- [ ] New character created with PDF → spell_dc_entries seeded correctly
- [ ] Non-caster PDF → no spell DC entries (empty list, no panel shown)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GoKnn1s4nMTfyWwB2WNHYE)_